### PR TITLE
chore: upgrade GitHub Actions runtime from node20 to node24

### DIFF
--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "24"
           cache: "npm"
       
       - name: Install dependencies

--- a/action.yml
+++ b/action.yml
@@ -62,5 +62,5 @@ inputs:
     default: ".github/code-reviewer.md"
 
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/index.js"


### PR DESCRIPTION
## Background

GitHub is deprecating Node.js 20 for Actions. Runners will force Node 24 by June 2, 2026, and Node 20 will be removed on September 16, 2026.

The existing workflow already shows the deprecation warning.

## Changes

- action.yml: using: node20 -> node24
- self-test.yml: node-version: 20 -> 24

## Backwards Compatibility

No functional changes. Node 24 is already supported on ubuntu-latest runners. The bundled dist/index.js targets CommonJS and runs on any supported Node version.