### PR TITLE
fix: support openrouter/free rotation without updating secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The easiest free setup uses [OpenRouter](https://openrouter.ai/):
 | `LLM_MODEL` | `openrouter/free` |
 
 > [!TIP]
-> `openrouter/free` picks a free model for each review — **$0 from OpenRouter**. You only spend [GitHub Actions](https://docs.github.com/en/billing/concepts/product-billing/github-actions) minutes while the job runs (often a few minutes per review).
+> `openrouter/free` picks a free model for each review — **$0 from OpenRouter**. OpenRouter rotates which model runs; **leave this secret as `openrouter/free`** — the action retries and uses provider fallbacks when a route is temporarily unavailable. You only spend [GitHub Actions](https://docs.github.com/en/billing/concepts/product-billing/github-actions) minutes while the job runs (often a few minutes per review).
 >
 > - **Public repos:** standard GitHub-hosted runners are free with no monthly minute cap.
 > - **Private repos:** GitHub Free includes about **2,000 minutes/month**; [GitHub Pro](https://docs.github.com/en/billing/concepts/product-billing/github-actions) includes about **3,000 minutes/month** (check your plan for current limits).
@@ -143,7 +143,8 @@ Add `.github/code-reviewer.md` in your repo:
 | Review never appears | Open **Actions** tab → open the failed run → read the error |
 | `/review` does nothing | Put `/review` on the **first** line; you need write access on the repo |
 | Review is very short | PR may be huge — see [docs/ADVANCED.md](docs/ADVANCED.md) (`max-diff-size`) |
-| `Empty response from LLM` | Free routers sometimes return no text — the action retries automatically (3 attempts); comment `/review` again or pin a model in `LLM_MODEL` |
+| `Empty response from LLM` | Free routers sometimes return no text — the action retries automatically; comment `/review` again |
+| `404 Provider returned error` | Normal for `openrouter/free` when one provider is down — the action retries up to 5 times; keep `LLM_MODEL=openrouter/free` |
 
 More fixes: [docs/ADVANCED.md#troubleshooting](docs/ADVANCED.md#troubleshooting)
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -50,11 +50,13 @@ function hasRequiredPermission(permission, minimumPermission) {
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.DEFAULT_LLM_RETRY_DELAY_MS = exports.DEFAULT_LLM_COMPLETION_ATTEMPTS = exports.DEFAULT_LLM_TIMEOUT_MS = void 0;
+exports.DEFAULT_LLM_ROUTER_RETRY_DELAY_MS = exports.DEFAULT_LLM_RETRY_DELAY_MS = exports.DEFAULT_LLM_ROUTER_COMPLETION_ATTEMPTS = exports.DEFAULT_LLM_COMPLETION_ATTEMPTS = exports.DEFAULT_LLM_TIMEOUT_MS = void 0;
 exports.parseLLMTimeout = parseLLMTimeout;
 exports.DEFAULT_LLM_TIMEOUT_MS = 600000; // 10 minutes
 exports.DEFAULT_LLM_COMPLETION_ATTEMPTS = 3;
+exports.DEFAULT_LLM_ROUTER_COMPLETION_ATTEMPTS = 5;
 exports.DEFAULT_LLM_RETRY_DELAY_MS = 2000;
+exports.DEFAULT_LLM_ROUTER_RETRY_DELAY_MS = 3000;
 function parseLLMTimeout(input) {
     if (!input)
         return { value: exports.DEFAULT_LLM_TIMEOUT_MS, valid: true };
@@ -558,7 +560,13 @@ class LLMClient {
             maxOutputTokens && Number.isFinite(maxOutputTokens) && maxOutputTokens > 0
                 ? maxOutputTokens
                 : undefined;
-        this.maxAttempts = (0, llm_retry_1.getLlmCompletionAttemptCount)(maxAttempts);
+        this.maxAttempts = (0, llm_retry_1.getLlmCompletionAttemptCount)(maxAttempts, model);
+        if ((0, llm_retry_1.isOpenRouterRouterModel)(model)) {
+            core.info("OpenRouter router model detected — using extra retries and provider fallbacks for rotating free models.");
+        }
+    }
+    retryContext() {
+        return { model: this.model };
     }
     async chatCompletion(systemPrompt, userContent, jsonResponseMode = false) {
         let lastFinishReason = "unknown";
@@ -579,18 +587,18 @@ class LLMClient {
             catch (error) {
                 lastError = error;
                 core.warning(`LLM attempt ${attempt}/${this.maxAttempts} failed: ${error}`);
-                if (!(0, llm_retry_1.isRetriableLlmError)(error) || attempt === this.maxAttempts) {
+                if (!(0, llm_retry_1.isRetriableLlmError)(error, this.retryContext()) || attempt === this.maxAttempts) {
                     core.error(`LLM API error: ${error}`);
                     throw new Error(`Failed to get response from LLM: ${error}`);
                 }
             }
             if (attempt < this.maxAttempts) {
-                const waitMs = (0, llm_retry_1.computeRetryDelayMs)(attempt);
+                const waitMs = (0, llm_retry_1.computeRetryDelayMs)(attempt, this.retryContext());
                 core.info(`Retrying LLM request in ${waitMs} ms (attempt ${attempt + 1}/${this.maxAttempts})...`);
                 await (0, llm_retry_1.delayMs)(waitMs);
             }
         }
-        if (lastError && (0, llm_retry_1.isRetriableLlmError)(lastError)) {
+        if (lastError && (0, llm_retry_1.isRetriableLlmError)(lastError, this.retryContext())) {
             core.error(`LLM API error after ${this.maxAttempts} attempts: ${lastError}`);
             throw new Error(`Failed to get response from LLM after ${this.maxAttempts} attempts: ${lastError}`);
         }
@@ -610,6 +618,10 @@ class LLMClient {
         }
         if (jsonResponseMode) {
             request.response_format = { type: "json_object" };
+        }
+        if ((0, llm_retry_1.isOpenRouterRouterModel)(this.model)) {
+            // OpenRouter extension: try other providers when the first free route 404s.
+            request.provider = { allow_fallbacks: true };
         }
         return request;
     }
@@ -646,18 +658,37 @@ exports.LLMClient = LLMClient;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.isOpenRouterRouterModel = isOpenRouterRouterModel;
+exports.isOpenRouterProviderError = isOpenRouterProviderError;
 exports.isRetriableLlmError = isRetriableLlmError;
 exports.shouldUseJsonResponseMode = shouldUseJsonResponseMode;
 exports.computeRetryDelayMs = computeRetryDelayMs;
 exports.getLlmCompletionAttemptCount = getLlmCompletionAttemptCount;
 exports.delayMs = delayMs;
 const config_1 = __nccwpck_require__(4008);
-function isRetriableLlmError(error) {
+/** OpenRouter routers (e.g. openrouter/free) pick models dynamically — no secret updates needed. */
+function isOpenRouterRouterModel(model) {
+    if (!model)
+        return false;
+    const normalized = model.trim().toLowerCase();
+    return (normalized === "openrouter/free" ||
+        normalized === "openrouter/auto" ||
+        normalized.startsWith("openrouter/") && normalized.endsWith("/free"));
+}
+function isOpenRouterProviderError(error) {
+    const message = (error instanceof Error ? error.message : String(error)).toLowerCase();
+    return message.includes("provider returned error");
+}
+function isRetriableLlmError(error, context = {}) {
     if (!error)
         return false;
+    const routerModel = isOpenRouterRouterModel(context.model);
     if (typeof error === "object" && error !== null && "status" in error) {
         const status = Number(error.status);
         if (status === 429 || (Number.isFinite(status) && status >= 500)) {
+            return true;
+        }
+        if (status === 404 && routerModel) {
             return true;
         }
         if (Number.isFinite(status) && status >= 400 && status < 500) {
@@ -665,6 +696,9 @@ function isRetriableLlmError(error) {
         }
     }
     const message = (error instanceof Error ? error.message : String(error)).toLowerCase();
+    if (routerModel && (message.includes("404") || isOpenRouterProviderError(error))) {
+        return true;
+    }
     return (message.includes("timeout") ||
         message.includes("timed out") ||
         message.includes("econnreset") ||
@@ -678,11 +712,16 @@ function isRetriableLlmError(error) {
 function shouldUseJsonResponseMode(attempt, jsonResponseMode) {
     return jsonResponseMode && attempt === 1;
 }
-function computeRetryDelayMs(attempt, baseDelayMs = config_1.DEFAULT_LLM_RETRY_DELAY_MS) {
+function computeRetryDelayMs(attempt, context = {}, baseDelayMs = isOpenRouterRouterModel(context.model)
+    ? config_1.DEFAULT_LLM_ROUTER_RETRY_DELAY_MS
+    : config_1.DEFAULT_LLM_RETRY_DELAY_MS) {
     return baseDelayMs * attempt;
 }
-function getLlmCompletionAttemptCount(maxAttempts = config_1.DEFAULT_LLM_COMPLETION_ATTEMPTS) {
-    return Math.max(1, Math.floor(maxAttempts));
+function getLlmCompletionAttemptCount(maxAttempts = config_1.DEFAULT_LLM_COMPLETION_ATTEMPTS, model) {
+    const resolved = maxAttempts === config_1.DEFAULT_LLM_COMPLETION_ATTEMPTS && isOpenRouterRouterModel(model)
+        ? config_1.DEFAULT_LLM_ROUTER_COMPLETION_ATTEMPTS
+        : maxAttempts;
+    return Math.max(1, Math.floor(resolved));
 }
 async function delayMs(ms) {
     await new Promise((resolve) => setTimeout(resolve, ms));

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -231,7 +231,8 @@ No daily quota from this action. Real limits:
 | `Connection refused` | Runner can't reach LLM URL | Public URL, tunnel, or self-hosted runner |
 | `Input required: model` | Missing secret | Add `LLM_MODEL` |
 | `Input required: llm-base-url` | Missing secret | Add `LLM_BASE_URL` |
-| `Empty response from LLM` | Free/unstable model returned no text | Action retries up to 3 times with backoff; comment `/review` again or pin a specific `LLM_MODEL` |
+| `Empty response from LLM` | Free/unstable model returned no text | Action retries with backoff; comment `/review` again |
+| `404 Provider returned error` | OpenRouter free route missed one provider | Keep `LLM_MODEL=openrouter/free` — action retries (5×) with provider fallbacks; no secret updates when models rotate |
 | `Request timed out` | Large PR or slow free model | Lower `max-diff-size` or raise `llm-timeout-ms` |
 | `Resource not accessible by integration` | Missing permissions | Add `pull-requests: write` |
 | Slash command ignored | Wrong format or permission | `/review` as first line; need write access |

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,8 @@
 export const DEFAULT_LLM_TIMEOUT_MS = 600000; // 10 minutes
 export const DEFAULT_LLM_COMPLETION_ATTEMPTS = 3;
+export const DEFAULT_LLM_ROUTER_COMPLETION_ATTEMPTS = 5;
 export const DEFAULT_LLM_RETRY_DELAY_MS = 2000;
+export const DEFAULT_LLM_ROUTER_RETRY_DELAY_MS = 3000;
 
 export function parseLLMTimeout(input: string): { value: number; valid: boolean } {
   if (!input) return { value: DEFAULT_LLM_TIMEOUT_MS, valid: true };

--- a/src/llm-client.ts
+++ b/src/llm-client.ts
@@ -4,6 +4,7 @@ import {
   computeRetryDelayMs,
   delayMs,
   getLlmCompletionAttemptCount,
+  isOpenRouterRouterModel,
   isRetriableLlmError,
   shouldUseJsonResponseMode,
 } from "./llm-retry";
@@ -44,7 +45,16 @@ export class LLMClient {
       maxOutputTokens && Number.isFinite(maxOutputTokens) && maxOutputTokens > 0
         ? maxOutputTokens
         : undefined;
-    this.maxAttempts = getLlmCompletionAttemptCount(maxAttempts);
+    this.maxAttempts = getLlmCompletionAttemptCount(maxAttempts, model);
+    if (isOpenRouterRouterModel(model)) {
+      core.info(
+        "OpenRouter router model detected — using extra retries and provider fallbacks for rotating free models."
+      );
+    }
+  }
+
+  private retryContext() {
+    return { model: this.model };
   }
 
   async chatCompletion(
@@ -78,20 +88,20 @@ export class LLMClient {
         lastError = error;
         core.warning(`LLM attempt ${attempt}/${this.maxAttempts} failed: ${error}`);
 
-        if (!isRetriableLlmError(error) || attempt === this.maxAttempts) {
+        if (!isRetriableLlmError(error, this.retryContext()) || attempt === this.maxAttempts) {
           core.error(`LLM API error: ${error}`);
           throw new Error(`Failed to get response from LLM: ${error}`);
         }
       }
 
       if (attempt < this.maxAttempts) {
-        const waitMs = computeRetryDelayMs(attempt);
+        const waitMs = computeRetryDelayMs(attempt, this.retryContext());
         core.info(`Retrying LLM request in ${waitMs} ms (attempt ${attempt + 1}/${this.maxAttempts})...`);
         await delayMs(waitMs);
       }
     }
 
-    if (lastError && isRetriableLlmError(lastError)) {
+    if (lastError && isRetriableLlmError(lastError, this.retryContext())) {
       core.error(`LLM API error after ${this.maxAttempts} attempts: ${lastError}`);
       throw new Error(
         `Failed to get response from LLM after ${this.maxAttempts} attempts: ${lastError}`
@@ -123,6 +133,13 @@ export class LLMClient {
 
     if (jsonResponseMode) {
       request.response_format = { type: "json_object" };
+    }
+
+    if (isOpenRouterRouterModel(this.model)) {
+      // OpenRouter extension: try other providers when the first free route 404s.
+      (request as OpenAI.Chat.Completions.ChatCompletionCreateParamsNonStreaming & {
+        provider?: { allow_fallbacks: boolean };
+      }).provider = { allow_fallbacks: true };
     }
 
     return request;

--- a/src/llm-retry.test.ts
+++ b/src/llm-retry.test.ts
@@ -1,9 +1,23 @@
 import {
   computeRetryDelayMs,
   getLlmCompletionAttemptCount,
+  isOpenRouterRouterModel,
   isRetriableLlmError,
   shouldUseJsonResponseMode,
 } from "./llm-retry";
+import {
+  DEFAULT_LLM_COMPLETION_ATTEMPTS,
+  DEFAULT_LLM_ROUTER_COMPLETION_ATTEMPTS,
+  DEFAULT_LLM_ROUTER_RETRY_DELAY_MS,
+} from "./config";
+
+describe("isOpenRouterRouterModel", () => {
+  it("detects OpenRouter free and auto routers", () => {
+    expect(isOpenRouterRouterModel("openrouter/free")).toBe(true);
+    expect(isOpenRouterRouterModel("openrouter/auto")).toBe(true);
+    expect(isOpenRouterRouterModel("gpt-4o")).toBe(false);
+  });
+});
 
 describe("isRetriableLlmError", () => {
   it("retries rate limits and server errors", () => {
@@ -20,6 +34,16 @@ describe("isRetriableLlmError", () => {
     expect(isRetriableLlmError(new Error("Request timed out"))).toBe(true);
     expect(isRetriableLlmError(new Error("ECONNRESET"))).toBe(true);
   });
+
+  it("retries OpenRouter provider 404s for router models", () => {
+    expect(
+      isRetriableLlmError(new Error("404 Provider returned error"), {
+        model: "openrouter/free",
+      })
+    ).toBe(true);
+    expect(isRetriableLlmError({ status: 404 }, { model: "openrouter/free" })).toBe(true);
+    expect(isRetriableLlmError({ status: 404 }, { model: "gpt-4o" })).toBe(false);
+  });
 });
 
 describe("shouldUseJsonResponseMode", () => {
@@ -32,8 +56,14 @@ describe("shouldUseJsonResponseMode", () => {
 
 describe("computeRetryDelayMs", () => {
   it("backs off linearly by attempt", () => {
-    expect(computeRetryDelayMs(1, 1000)).toBe(1000);
-    expect(computeRetryDelayMs(2, 1000)).toBe(2000);
+    expect(computeRetryDelayMs(1, {}, 1000)).toBe(1000);
+    expect(computeRetryDelayMs(2, {}, 1000)).toBe(2000);
+  });
+
+  it("uses longer base delay for router models", () => {
+    expect(computeRetryDelayMs(1, { model: "openrouter/free" })).toBe(
+      DEFAULT_LLM_ROUTER_RETRY_DELAY_MS
+    );
   });
 });
 
@@ -41,5 +71,14 @@ describe("getLlmCompletionAttemptCount", () => {
   it("clamps invalid values to at least one", () => {
     expect(getLlmCompletionAttemptCount(0)).toBe(1);
     expect(getLlmCompletionAttemptCount(2.7)).toBe(2);
+  });
+
+  it("uses more attempts for OpenRouter router models by default", () => {
+    expect(getLlmCompletionAttemptCount(DEFAULT_LLM_COMPLETION_ATTEMPTS, "openrouter/free")).toBe(
+      DEFAULT_LLM_ROUTER_COMPLETION_ATTEMPTS
+    );
+    expect(getLlmCompletionAttemptCount(DEFAULT_LLM_COMPLETION_ATTEMPTS, "gpt-4o")).toBe(
+      DEFAULT_LLM_COMPLETION_ATTEMPTS
+    );
   });
 });

--- a/src/llm-retry.ts
+++ b/src/llm-retry.ts
@@ -1,14 +1,41 @@
 import {
   DEFAULT_LLM_COMPLETION_ATTEMPTS,
   DEFAULT_LLM_RETRY_DELAY_MS,
+  DEFAULT_LLM_ROUTER_COMPLETION_ATTEMPTS,
+  DEFAULT_LLM_ROUTER_RETRY_DELAY_MS,
 } from "./config";
 
-export function isRetriableLlmError(error: unknown): boolean {
+export interface LlmRetryContext {
+  model?: string;
+}
+
+/** OpenRouter routers (e.g. openrouter/free) pick models dynamically — no secret updates needed. */
+export function isOpenRouterRouterModel(model: string | undefined): boolean {
+  if (!model) return false;
+  const normalized = model.trim().toLowerCase();
+  return (
+    normalized === "openrouter/free" ||
+    normalized === "openrouter/auto" ||
+    normalized.startsWith("openrouter/") && normalized.endsWith("/free")
+  );
+}
+
+export function isOpenRouterProviderError(error: unknown): boolean {
+  const message = (error instanceof Error ? error.message : String(error)).toLowerCase();
+  return message.includes("provider returned error");
+}
+
+export function isRetriableLlmError(error: unknown, context: LlmRetryContext = {}): boolean {
   if (!error) return false;
+
+  const routerModel = isOpenRouterRouterModel(context.model);
 
   if (typeof error === "object" && error !== null && "status" in error) {
     const status = Number((error as { status?: number }).status);
     if (status === 429 || (Number.isFinite(status) && status >= 500)) {
+      return true;
+    }
+    if (status === 404 && routerModel) {
       return true;
     }
     if (Number.isFinite(status) && status >= 400 && status < 500) {
@@ -17,6 +44,10 @@ export function isRetriableLlmError(error: unknown): boolean {
   }
 
   const message = (error instanceof Error ? error.message : String(error)).toLowerCase();
+  if (routerModel && (message.includes("404") || isOpenRouterProviderError(error))) {
+    return true;
+  }
+
   return (
     message.includes("timeout") ||
     message.includes("timed out") ||
@@ -39,15 +70,23 @@ export function shouldUseJsonResponseMode(
 
 export function computeRetryDelayMs(
   attempt: number,
-  baseDelayMs = DEFAULT_LLM_RETRY_DELAY_MS
+  context: LlmRetryContext = {},
+  baseDelayMs = isOpenRouterRouterModel(context.model)
+    ? DEFAULT_LLM_ROUTER_RETRY_DELAY_MS
+    : DEFAULT_LLM_RETRY_DELAY_MS
 ): number {
   return baseDelayMs * attempt;
 }
 
 export function getLlmCompletionAttemptCount(
-  maxAttempts = DEFAULT_LLM_COMPLETION_ATTEMPTS
+  maxAttempts = DEFAULT_LLM_COMPLETION_ATTEMPTS,
+  model?: string
 ): number {
-  return Math.max(1, Math.floor(maxAttempts));
+  const resolved =
+    maxAttempts === DEFAULT_LLM_COMPLETION_ATTEMPTS && isOpenRouterRouterModel(model)
+      ? DEFAULT_LLM_ROUTER_COMPLETION_ATTEMPTS
+      : maxAttempts;
+  return Math.max(1, Math.floor(resolved));
 }
 
 export async function delayMs(ms: number): Promise<void> {


### PR DESCRIPTION
## Summary
- Detect `openrouter/free` (and similar routers) and **retry 404 / Provider returned error** instead of failing on the first miss
- Send OpenRouter `provider.allow_fallbacks: true` on router models
- Use **5 attempts** and **3s** linear backoff for routers (vs 3 / 2s for pinned models)
- Document that users can keep `LLM_MODEL=openrouter/free` permanently

## Why
OpenRouter rotates free models (e.g. DeepSeek V4 Flash today, another tomorrow). Pinning `LLM_MODEL` to a specific slug breaks when models change. A single provider 404 often succeeds seconds later on another route — same as your dashboard generation vs the failed CI run.

## Test plan
- [x] `npm test` (44 tests)
- [x] `npm run build` + `dist/index.js` updated
- [ ] Merge and comment `/review` on a PR with `LLM_MODEL=openrouter/free` unchanged


Made with [Cursor](https://cursor.com)