### PR TITLE
Support self-hosted review runners

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -48,6 +48,11 @@ on:
         required: false
         type: boolean
         default: false
+      runner:
+        description: "Runner label or JSON array of labels to use for the review job."
+        required: false
+        type: string
+        default: '"ubuntu-latest"'
     secrets:
       LLM_API_KEY:
         required: true
@@ -78,7 +83,7 @@ jobs:
           startsWith(github.event.comment.body, '/help')
         )
       )
-    runs-on: ubuntu-latest
+    runs-on: ${{ fromJSON(inputs.runner) }}
     timeout-minutes: 15
     steps:
       - name: Universal Code Reviewer

--- a/README.md
+++ b/README.md
@@ -97,6 +97,31 @@ Commit and push. Open a pull request — you should see a review within a few mi
 > [!IMPORTANT]
 > Use **`@main`** for the latest fixes, or pin a release tag (for example `@v1` or `@v1.0.0`) after [releases](https://github.com/antongulin/universal-code-reviewer/releases) exist. Do **not** use `@v0`. See [Version pins](#version-pins) below.
 
+### Optional — run reviews on a self-hosted runner
+
+By default, the reusable workflow runs on GitHub's `ubuntu-latest` runner. To run reviews on your own runner, pass `runner` as valid JSON. Use a JSON string for one label or a JSON array for multiple labels.
+
+For a Coolify self-hosted runner:
+
+```yaml
+jobs:
+  review:
+    uses: antongulin/universal-code-reviewer/.github/workflows/review.yml@main
+    with:
+      runner: '["self-hosted", "linux", "coolify"]'
+    secrets:
+      LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+      LLM_BASE_URL: ${{ secrets.LLM_BASE_URL }}
+      LLM_MODEL: ${{ secrets.LLM_MODEL }}
+```
+
+For a single runner label:
+
+```yaml
+with:
+  runner: '"ubuntu-latest"'
+```
+
 ## Using it day to day
 
 | When | What happens |

--- a/README.md
+++ b/README.md
@@ -97,11 +97,52 @@ Commit and push. Open a pull request — you should see a review within a few mi
 > [!IMPORTANT]
 > Use **`@main`** for the latest fixes, or pin a release tag (for example `@v1` or `@v1.0.0`) after [releases](https://github.com/antongulin/universal-code-reviewer/releases) exist. Do **not** use `@v0`. See [Version pins](#version-pins) below.
 
-### Optional — run reviews on a self-hosted runner
+## Running on a self-hosted runner
 
-By default, the reusable workflow runs on GitHub's `ubuntu-latest` runner. To run reviews on your own runner, pass `runner` as valid JSON. Use a JSON string for one label or a JSON array for multiple labels.
+By default, the reusable workflow runs on GitHub's hosted `ubuntu-latest` runner:
 
-For a Coolify self-hosted runner:
+```yaml
+with:
+  runner: '"ubuntu-latest"'
+```
+
+To run reviews on your own machine, Mac mini, home server, local Linux box, or Coolify runner, pass `runner` as valid JSON. Use a JSON string for one label or a JSON array for multiple labels.
+
+To create a local runner, go to:
+
+```text
+Repository Settings -> Actions -> Runners -> New self-hosted runner
+```
+
+Then add labels such as `local`, `linux`, `mac`, or `coolify`, and reference those labels through the `runner` input.
+
+### Does the runner need to run all the time?
+
+A matching self-hosted runner must be online when GitHub starts the review job. It can be a local runner process (`./run.sh`), a service (`./svc.sh start`), a Docker container, or a Coolify-managed service. Docker is optional; it is just one way to run the GitHub Actions runner.
+
+If no matching runner is online, GitHub queues the job until one comes online. It will not fall back to `ubuntu-latest` unless you add a separate fallback job. For reliable PR reviews, keep an always-on runner available, such as a Mac mini, home server, VPS, or Coolify service. A laptop runner only works while the laptop is awake and the runner process or service is running.
+
+> [!WARNING]
+> Self-hosted runners can execute arbitrary workflow code.
+> Do not use them for untrusted public pull requests.
+> Prefer repo-owned private repos or trusted collaborators only.
+> Consider ephemeral runners for stronger isolation.
+
+Local machine runner:
+
+```yaml
+jobs:
+  review:
+    uses: antongulin/universal-code-reviewer/.github/workflows/review.yml@main
+    with:
+      runner: '["self-hosted", "local"]'
+    secrets:
+      LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+      LLM_BASE_URL: ${{ secrets.LLM_BASE_URL }}
+      LLM_MODEL: ${{ secrets.LLM_MODEL }}
+```
+
+Coolify runner:
 
 ```yaml
 jobs:
@@ -113,13 +154,6 @@ jobs:
       LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
       LLM_BASE_URL: ${{ secrets.LLM_BASE_URL }}
       LLM_MODEL: ${{ secrets.LLM_MODEL }}
-```
-
-For a single runner label:
-
-```yaml
-with:
-  runner: '"ubuntu-latest"'
 ```
 
 ## Using it day to day

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -81,6 +81,22 @@ jobs:
 - **Private repos:** GitHub Free includes about **2,000 minutes/month**; GitHub Pro about **3,000 minutes/month** (limits can change — see GitHub billing for your account).
 - **Private repos (heavy usage):** use a [self-hosted runner](https://docs.github.com/en/actions/hosting-your-own-runners) so LLM wait time does not consume hosted minutes.
 
+To use a self-hosted runner with the reusable workflow, pass `runner` as valid JSON. A single label is a JSON string; multiple labels are a JSON array.
+
+Coolify example:
+
+```yaml
+jobs:
+  review:
+    uses: antongulin/universal-code-reviewer/.github/workflows/review.yml@main
+    with:
+      runner: '["self-hosted", "linux", "coolify"]'
+    secrets:
+      LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+      LLM_BASE_URL: ${{ secrets.LLM_BASE_URL }}
+      LLM_MODEL: ${{ secrets.LLM_MODEL }}
+```
+
 ## All workflow inputs
 
 Available on the [direct action](../action.yml) and the [reusable workflow](../.github/workflows/review.yml).
@@ -97,6 +113,7 @@ Available on the [direct action](../action.yml) and the [reusable workflow](../.
 | `llm-timeout-ms` | `600000` | LLM timeout (10 minutes) |
 | `max-comments` | `25` (action) / `10` (reusable workflow) | Max inline comments |
 | `review-on-synchronize` | `false` | Review every new commit on the PR |
+| `runner` | `'"ubuntu-latest"'` | Reusable workflow runner as a JSON string or JSON array |
 | `min-command-permission` | `write` | Who can run `/review` |
 | `review-instructions` | empty | Extra prompt text |
 | `review-instructions-file` | `.github/code-reviewer.md` | Rules file on the base branch |

--- a/src/workflow.test.ts
+++ b/src/workflow.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const repoRoot = join(__dirname, "..");
+const reviewWorkflow = readFileSync(
+  join(repoRoot, ".github", "workflows", "review.yml"),
+  "utf8",
+);
+const readme = readFileSync(join(repoRoot, "README.md"), "utf8");
+
+describe("reusable review workflow", () => {
+  it("lets callers choose a GitHub-hosted or self-hosted runner", () => {
+    expect(reviewWorkflow).toContain("runner:");
+    expect(reviewWorkflow).toContain(
+      'description: "Runner label or JSON array of labels to use for the review job."',
+    );
+    expect(reviewWorkflow).toContain("default: '\"ubuntu-latest\"'");
+    expect(reviewWorkflow).toContain("runs-on: ${{ fromJSON(inputs.runner) }}");
+  });
+
+  it("documents Coolify self-hosted runner usage", () => {
+    expect(readme).toContain(
+      "runner: '[\"self-hosted\", \"linux\", \"coolify\"]'",
+    );
+  });
+});

--- a/src/workflow.test.ts
+++ b/src/workflow.test.ts
@@ -18,9 +18,27 @@ describe("reusable review workflow", () => {
     expect(reviewWorkflow).toContain("runs-on: ${{ fromJSON(inputs.runner) }}");
   });
 
-  it("documents Coolify self-hosted runner usage", () => {
+  it("documents local and Coolify self-hosted runner usage", () => {
+    expect(readme).toContain("## Running on a self-hosted runner");
+    expect(readme).toContain("runner: '[\"self-hosted\", \"local\"]'");
     expect(readme).toContain(
       "runner: '[\"self-hosted\", \"linux\", \"coolify\"]'",
+    );
+    expect(readme).toContain("runner: '\"ubuntu-latest\"'");
+    expect(readme).toContain(
+      "Self-hosted runners can execute arbitrary workflow code.",
+    );
+    expect(readme).toContain(
+      "Repository Settings -> Actions -> Runners -> New self-hosted runner",
+    );
+    expect(readme).toContain(
+      "A matching self-hosted runner must be online when GitHub starts the review job.",
+    );
+    expect(readme).toContain(
+      "Docker is optional; it is just one way to run the GitHub Actions runner.",
+    );
+    expect(readme).toContain(
+      "If no matching runner is online, GitHub queues the job until one comes online.",
     );
   });
 });


### PR DESCRIPTION
## Summary
- Add a reusable workflow `runner` input that accepts JSON strings or arrays of runner labels
- Document GitHub-hosted defaults plus local, Coolify, and always-on self-hosted runner usage
- Add regression coverage for the reusable workflow and README examples

## Verification
- npm run lint
- npm test
- npm run build
- git diff --exit-code dist/index.js
- git diff --check origin/main...HEAD