### PR TITLE
Automate release publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,8 @@ jobs:
           RELEASE_PR: ${{ needs.release-please.outputs.pr }}
           RELEASE_PRS: ${{ needs.release-please.outputs.prs }}
         run: |
+          set -euo pipefail
+
           number=$(
             node -e '
               const pr = process.env.RELEASE_PR;
@@ -75,8 +77,8 @@ jobs:
             '
           )
 
-          if [ -z "$number" ]; then
-            echo "Release Please reported a PR but no PR number was available." >&2
+          if [ -z "$number" ] || [[ ! "$number" =~ ^[0-9]+$ ]]; then
+            echo "Release Please reported an invalid PR number: $number" >&2
             exit 1
           fi
 
@@ -87,6 +89,8 @@ jobs:
 
       - name: Verify release PR
         run: |
+          set -euo pipefail
+
           npm ci
           npm run lint
           npm test
@@ -97,6 +101,8 @@ jobs:
         id: merge
         shell: bash
         run: |
+          set -euo pipefail
+
           number="${{ steps.release-pr.outputs.number }}"
           gh pr merge "$number" --merge --delete-branch
           merge_sha=$(gh pr view "$number" --json mergeCommit -q '.mergeCommit.oid')
@@ -106,12 +112,14 @@ jobs:
             exit 1
           fi
 
-          git fetch origin main --tags --force
+          git fetch origin main --tags --force || { echo "Fetch failed" >&2; exit 1; }
           echo "merge_sha=$merge_sha" >> "$GITHUB_OUTPUT"
 
       - name: Create release and update floating tags
         shell: bash
         run: |
+          set -euo pipefail
+
           merge_sha="${{ steps.merge.outputs.merge_sha }}"
           version=$(
             git show "$merge_sha:.release-please-manifest.json" |
@@ -130,6 +138,8 @@ jobs:
           fi
 
           tag="v$version"
+          git fetch origin --tags --force || { echo "Fetch tags failed" >&2; exit 1; }
+
           notes=$(
             git show "$merge_sha:CHANGELOG.md" |
               awk -v version="$version" '
@@ -139,7 +149,17 @@ jobs:
               '
           )
 
+          if [ -z "$notes" ] || ! grep -q "^## \\[$version\\]" <<<"$notes"; then
+            echo "Release notes for $tag were empty or malformed." >&2
+            exit 1
+          fi
+
           if gh release view "$tag" >/dev/null 2>&1; then
+            existing_sha=$(git rev-list -n 1 "$tag" 2>/dev/null || true)
+            if [ -n "$existing_sha" ] && [ "$existing_sha" != "$merge_sha" ]; then
+              echo "Existing release tag $tag points to $existing_sha, not $merge_sha." >&2
+              exit 1
+            fi
             echo "Release $tag already exists."
           else
             gh release create "$tag" \
@@ -151,6 +171,7 @@ jobs:
           IFS=. read -r major minor _patch <<<"$version"
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          # Floating tags intentionally move to the latest release in each stream.
           git tag -f "v$major" "$merge_sha"
           git tag -f "v$major.$minor" "$merge_sha"
           git push origin -f "v$major" "v$major.$minor"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
 
 concurrency:
   group: release-please-${{ github.ref }}
@@ -22,11 +23,120 @@ jobs:
       tag_name: ${{ steps.release.outputs.tag_name }}
       major: ${{ steps.release.outputs.major }}
       minor: ${{ steps.release.outputs.minor }}
+      prs_created: ${{ steps.release.outputs.prs_created }}
+      pr: ${{ steps.release.outputs.pr }}
+      prs: ${{ steps.release.outputs.prs }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  auto-release:
+    needs: release-please
+    if: needs.release-please.outputs.prs_created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: npm
+
+      - name: Extract release PR number
+        id: release-pr
+        shell: bash
+        env:
+          RELEASE_PR: ${{ needs.release-please.outputs.pr }}
+          RELEASE_PRS: ${{ needs.release-please.outputs.prs }}
+        run: |
+          pr_json="$RELEASE_PR"
+          if [ -n "$pr_json" ] && [ "$pr_json" != "null" ]; then
+            number=$(jq -r '.number // empty' <<<"$pr_json")
+          else
+            prs_json="$RELEASE_PRS"
+            number=$(jq -r '.[0].number // empty' <<<"$prs_json")
+          fi
+
+          if [ -z "$number" ]; then
+            echo "Release Please reported a PR but no PR number was available." >&2
+            exit 1
+          fi
+
+          echo "number=$number" >> "$GITHUB_OUTPUT"
+
+      - name: Check out release PR
+        run: gh pr checkout "${{ steps.release-pr.outputs.number }}"
+
+      - name: Verify release PR
+        run: |
+          npm ci
+          npm run lint
+          npm test
+          npm run build
+          git diff --exit-code dist/index.js
+
+      - name: Merge release PR
+        id: merge
+        shell: bash
+        run: |
+          number="${{ steps.release-pr.outputs.number }}"
+          gh pr merge "$number" --merge --delete-branch
+          merge_sha=$(gh pr view "$number" --json mergeCommit -q '.mergeCommit.oid')
+
+          if [ -z "$merge_sha" ] || [ "$merge_sha" = "null" ]; then
+            echo "Release PR merged but merge commit was not available." >&2
+            exit 1
+          fi
+
+          git fetch origin main --tags --force
+          echo "merge_sha=$merge_sha" >> "$GITHUB_OUTPUT"
+
+      - name: Create release and update floating tags
+        shell: bash
+        run: |
+          merge_sha="${{ steps.merge.outputs.merge_sha }}"
+          version=$(git show "$merge_sha:.release-please-manifest.json" | jq -r '."."')
+
+          if [ -z "$version" ] || [ "$version" = "null" ]; then
+            echo "Could not read release version from manifest." >&2
+            exit 1
+          fi
+
+          tag="v$version"
+          notes=$(
+            git show "$merge_sha:CHANGELOG.md" |
+              awk -v version="$version" '
+                $0 ~ "^## \\[" version "\\]" { capture = 1; print; next }
+                capture && /^## \\[/ { exit }
+                capture { print }
+              '
+          )
+
+          if gh release view "$tag" >/dev/null 2>&1; then
+            echo "Release $tag already exists."
+          else
+            gh release create "$tag" \
+              --target "$merge_sha" \
+              --title "$tag" \
+              --notes "$notes"
+          fi
+
+          IFS=. read -r major minor _patch <<<"$version"
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git tag -f "v$major" "$merge_sha"
+          git tag -f "v$major.$minor" "$merge_sha"
+          git push origin -f "v$major" "v$major.$minor"
 
   verify-release:
     needs: release-please

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,13 +59,21 @@ jobs:
           RELEASE_PR: ${{ needs.release-please.outputs.pr }}
           RELEASE_PRS: ${{ needs.release-please.outputs.prs }}
         run: |
-          pr_json="$RELEASE_PR"
-          if [ -n "$pr_json" ] && [ "$pr_json" != "null" ]; then
-            number=$(jq -r '.number // empty' <<<"$pr_json")
-          else
-            prs_json="$RELEASE_PRS"
-            number=$(jq -r '.[0].number // empty' <<<"$prs_json")
-          fi
+          number=$(
+            node -e '
+              const pr = process.env.RELEASE_PR;
+              const prs = process.env.RELEASE_PRS;
+              let number = "";
+
+              if (pr && pr !== "null") {
+                number = JSON.parse(pr).number ?? "";
+              } else if (prs && prs !== "null") {
+                number = (JSON.parse(prs)[0] ?? {}).number ?? "";
+              }
+
+              process.stdout.write(String(number));
+            '
+          )
 
           if [ -z "$number" ]; then
             echo "Release Please reported a PR but no PR number was available." >&2
@@ -105,7 +113,16 @@ jobs:
         shell: bash
         run: |
           merge_sha="${{ steps.merge.outputs.merge_sha }}"
-          version=$(git show "$merge_sha:.release-please-manifest.json" | jq -r '."."')
+          version=$(
+            git show "$merge_sha:.release-please-manifest.json" |
+              node -e '
+                let input = "";
+                process.stdin.on("data", chunk => input += chunk);
+                process.stdin.on("end", () => {
+                  process.stdout.write(JSON.parse(input)["."] ?? "");
+                });
+              '
+          )
 
           if [ -z "$version" ] || [ "$version" = "null" ]; then
             echo "Could not read release version from manifest." >&2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,6 @@ Merges to `main` use [Release Please](https://github.com/googleapis/release-plea
 | `fix:` | Patch | `fix: skip composer.lock in diff filter` |
 | `feat!:` or `BREAKING CHANGE:` | Major | `feat!: remove deprecated fail-on-critical input` |
 
-When a release is ready, the **Release** workflow opens or updates a `chore: release X.Y.Z` pull request. Merging it creates the GitHub release, tag, and floating `@v1` / `@v1.0` tags.
+When a release is ready, the **Release** workflow opens or updates a `chore: release X.Y.Z` pull request. Release PRs are verified, merged, and published automatically by the workflow. The workflow creates the GitHub release, exact tag, and floating `@v1` / `@v1.0` tags without a manual maintainer merge.
 
-**Repository setting (one-time):** In **Settings → Actions → General → Workflow permissions**, choose **Read and write permissions** and enable **Allow GitHub Actions to create and approve pull requests**. Without this, Release Please cannot open release PRs.
+**Repository setting (one-time):** In **Settings → Actions → General → Workflow permissions**, choose **Read and write permissions** and enable **Allow GitHub Actions to create and approve pull requests**. Without this, Release Please cannot open or merge release PRs.

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -44,10 +44,11 @@ uses: antongulin/universal-code-reviewer/.github/workflows/review.yml@v1
 Releases are automated with [Release Please](https://github.com/googleapis/release-please) (`.github/workflows/release.yml`):
 
 1. Conventional commits on `main` accumulate in a **Release** pull request (`chore: release X.Y.Z`).
-2. Merging that PR updates `package.json`, `CHANGELOG.md`, creates tag `vX.Y.Z`, and publishes [GitHub release notes](https://github.com/antongulin/universal-code-reviewer/releases).
-3. Floating tags `v1` and `v1.0` (major.minor) are updated so `@v1` stays current within the major version.
+2. Release PRs are verified, merged, and published automatically by the workflow.
+3. The workflow updates `package.json`, `CHANGELOG.md`, creates tag `vX.Y.Z`, and publishes [GitHub release notes](https://github.com/antongulin/universal-code-reviewer/releases).
+4. Floating tags `v1` and `v1.0` (major.minor) are updated so `@v1` stays current within the major version.
 
-Maintainers: do not tag releases by hand unless the workflow failed; fix the workflow instead.
+Maintainers: do not tag releases by hand unless the workflow failed; fix or rerun the workflow instead.
 
 ## Low-cost and free setups
 

--- a/src/release-workflow.test.ts
+++ b/src/release-workflow.test.ts
@@ -24,6 +24,10 @@ describe("release workflow", () => {
     expect(releaseWorkflow).toContain("gh pr merge \"$number\" --merge --delete-branch");
     expect(releaseWorkflow).toContain("gh release create \"$tag\"");
     expect(releaseWorkflow).toContain("git push origin -f \"v$major\" \"v$major.$minor\"");
+    expect(releaseWorkflow).toContain("[[ ! \"$number\" =~ ^[0-9]+$ ]]");
+    expect(releaseWorkflow).toContain("set -euo pipefail");
+    expect(releaseWorkflow).toContain("Release notes for $tag were empty or malformed.");
+    expect(releaseWorkflow).toContain("Existing release tag $tag points to");
     expect(releaseWorkflow).not.toContain("jq ");
   });
 

--- a/src/release-workflow.test.ts
+++ b/src/release-workflow.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const repoRoot = join(__dirname, "..");
+const releaseWorkflow = readFileSync(
+  join(repoRoot, ".github", "workflows", "release.yml"),
+  "utf8",
+);
+const contributing = readFileSync(join(repoRoot, "CONTRIBUTING.md"), "utf8");
+const advancedDocs = readFileSync(join(repoRoot, "docs", "ADVANCED.md"), "utf8");
+
+describe("release workflow", () => {
+  it("automatically verifies, merges, and publishes release PRs", () => {
+    expect(releaseWorkflow).toContain("prs_created:");
+    expect(releaseWorkflow).toContain("pr: ${{ steps.release.outputs.pr }}");
+    expect(releaseWorkflow).toContain("auto-release:");
+    expect(releaseWorkflow).toContain(
+      "if: needs.release-please.outputs.prs_created == 'true'",
+    );
+    expect(releaseWorkflow).toContain("gh pr merge \"$number\" --merge --delete-branch");
+    expect(releaseWorkflow).toContain("gh release create \"$tag\"");
+    expect(releaseWorkflow).toContain("git push origin -f \"v$major\" \"v$major.$minor\"");
+  });
+
+  it("documents that releases publish automatically after merges to main", () => {
+    expect(contributing).toContain(
+      "Release PRs are verified, merged, and published automatically by the workflow.",
+    );
+    expect(advancedDocs).toContain(
+      "Release PRs are verified, merged, and published automatically by the workflow.",
+    );
+  });
+});

--- a/src/release-workflow.test.ts
+++ b/src/release-workflow.test.ts
@@ -11,15 +11,20 @@ const advancedDocs = readFileSync(join(repoRoot, "docs", "ADVANCED.md"), "utf8")
 
 describe("release workflow", () => {
   it("automatically verifies, merges, and publishes release PRs", () => {
-    expect(releaseWorkflow).toContain("prs_created:");
-    expect(releaseWorkflow).toContain("pr: ${{ steps.release.outputs.pr }}");
-    expect(releaseWorkflow).toContain("auto-release:");
+    expect(releaseWorkflow).toMatch(
+      /prs_created:\s*\$\{\{\s*steps\.release\.outputs\.prs_created\s*\}\}/,
+    );
+    expect(releaseWorkflow).toMatch(
+      /pr:\s*\$\{\{\s*steps\.release\.outputs\.pr\s*\}\}/,
+    );
+    expect(releaseWorkflow).toMatch(/\n  auto-release:\n/);
     expect(releaseWorkflow).toContain(
       "if: needs.release-please.outputs.prs_created == 'true'",
     );
     expect(releaseWorkflow).toContain("gh pr merge \"$number\" --merge --delete-branch");
     expect(releaseWorkflow).toContain("gh release create \"$tag\"");
     expect(releaseWorkflow).toContain("git push origin -f \"v$major\" \"v$major.$minor\"");
+    expect(releaseWorkflow).not.toContain("jq ");
   });
 
   it("documents that releases publish automatically after merges to main", () => {


### PR DESCRIPTION
## Summary
- Add an `auto-release` job that verifies Release Please PRs, merges them, creates the GitHub release, and updates floating tags
- Document the fully automatic release flow in maintainer docs
- Add regression coverage for the release workflow contract

## Verification
- Ruby YAML parse check for `.github/workflows/release.yml`
- npm run lint
- npm test
- npm run build
- git diff --exit-code dist/index.js
- git diff --check