### PR TITLE
fix: repair auto-release notes extraction

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,7 +144,7 @@ jobs:
             git show "$merge_sha:CHANGELOG.md" |
               awk -v version="$version" '
                 $0 ~ "^## \\[" version "\\]" { capture = 1; print; next }
-                capture && /^## \\[/ { exit }
+                capture && /^## \[/ { exit }
                 capture { print }
               '
           )

--- a/src/release-workflow.test.ts
+++ b/src/release-workflow.test.ts
@@ -10,6 +10,38 @@ const releaseWorkflow = readFileSync(
 const contributing = readFileSync(join(repoRoot, "CONTRIBUTING.md"), "utf8");
 const advancedDocs = readFileSync(join(repoRoot, "docs", "ADVANCED.md"), "utf8");
 
+function getWorkflowRunStep(workflow: string, stepName: string): string {
+  const lines = workflow.split("\n");
+  const stepIndex = lines.findIndex((line) => line.trim() === `- name: ${stepName}`);
+
+  if (stepIndex === -1) {
+    throw new Error(`Could not find workflow step: ${stepName}`);
+  }
+
+  const runIndex = lines.findIndex(
+    (line, index) => index > stepIndex && line.trim() === "run: |",
+  );
+
+  if (runIndex === -1) {
+    throw new Error(`Could not find run block for workflow step: ${stepName}`);
+  }
+
+  const runIndent = lines[runIndex].match(/^ */)?.[0].length ?? 0;
+  const runBlock: string[] = [];
+
+  for (const line of lines.slice(runIndex + 1)) {
+    const indent = line.match(/^ */)?.[0].length ?? 0;
+
+    if (line.trim() !== "" && indent <= runIndent) {
+      break;
+    }
+
+    runBlock.push(line.slice(runIndent + 2));
+  }
+
+  return runBlock.join("\n");
+}
+
 describe("release workflow", () => {
   it("automatically verifies, merges, and publishes release PRs", () => {
     expect(releaseWorkflow).toMatch(
@@ -42,15 +74,18 @@ describe("release workflow", () => {
   });
 
   it("extracts release notes with shell syntax that runs on ubuntu-latest", () => {
-    const awkMatch = releaseWorkflow.match(
-      /awk -v version="\$version" '\n([\s\S]*?)\n\s*'/,
+    const releaseStep = getWorkflowRunStep(
+      releaseWorkflow,
+      "Create release and update floating tags",
     );
+    const awkMatch = releaseStep.match(/awk -v version="\$version" '\n([\s\S]*?)\n\s*'/);
 
     expect(awkMatch).not.toBeNull();
+    expect(awkMatch?.[1]).toBeDefined();
 
     const awkProgram = awkMatch![1]
       .split("\n")
-      .map((line) => line.replace(/^ {16}/, ""))
+      .map((line) => line.trimStart())
       .join("\n");
 
     const changelog = [

--- a/src/release-workflow.test.ts
+++ b/src/release-workflow.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "child_process";
 import { readFileSync } from "fs";
 import { join } from "path";
 
@@ -38,5 +39,42 @@ describe("release workflow", () => {
     expect(advancedDocs).toContain(
       "Release PRs are verified, merged, and published automatically by the workflow.",
     );
+  });
+
+  it("extracts release notes with shell syntax that runs on ubuntu-latest", () => {
+    const awkMatch = releaseWorkflow.match(
+      /awk -v version="\$version" '\n([\s\S]*?)\n\s*'/,
+    );
+
+    expect(awkMatch).not.toBeNull();
+
+    const awkProgram = awkMatch![1]
+      .split("\n")
+      .map((line) => line.replace(/^ {16}/, ""))
+      .join("\n");
+
+    const changelog = [
+      "# Changelog",
+      "",
+      "## [1.2.1](https://example.com/compare/v1.2.0...v1.2.1) (2026-05-19)",
+      "",
+      "### Bug Fixes",
+      "",
+      "* harden auto release workflow",
+      "",
+      "## [1.2.0](https://example.com/compare/v1.1.2...v1.2.0) (2026-05-18)",
+      "",
+      "* previous release",
+      "",
+    ].join("\n");
+
+    const notes = execFileSync("awk", ["-v", "version=1.2.1", awkProgram], {
+      input: changelog,
+      encoding: "utf8",
+    });
+
+    expect(notes).toContain("## [1.2.1]");
+    expect(notes).toContain("* harden auto release workflow");
+    expect(notes).not.toContain("## [1.2.0]");
   });
 });


### PR DESCRIPTION
## Summary
- fix the release workflow changelog section extractor so awk runs on ubuntu-latest
- add a regression test that executes the extractor against sample changelog input

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release workflow yaml ok"'
- git diff --check
- npm test -- --runTestsByPath src/release-workflow.test.ts
- npm run lint
- npm test
- npm run build
- git diff --exit-code dist/index.js

## Context
The failed run merged Release Please PR #18 but failed before creating the v1.2.1 GitHub release because awk parsed the over-escaped heading regex as an unterminated character class.