### PR TITLE
fix: keep Release Please in PR-only mode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,6 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
-      major: ${{ steps.release.outputs.major }}
-      minor: ${{ steps.release.outputs.minor }}
       prs_created: ${{ steps.release.outputs.prs_created }}
       pr: ${{ steps.release.outputs.pr }}
       prs: ${{ steps.release.outputs.prs }}
@@ -178,35 +174,3 @@ jobs:
           git tag -f "v$major" "$merge_sha"
           git tag -f "v$major.$minor" "$merge_sha"
           git push origin -f "v$major" "v$major.$minor"
-
-  verify-release:
-    needs: release-please
-    if: needs.release-please.outputs.release_created == 'true'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ needs.release-please.outputs.tag_name }}
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "24"
-          cache: npm
-
-      - name: Verify build on release tag
-        run: |
-          npm ci
-          npm run lint
-          npm test
-          npm run build
-          git diff --exit-code dist/index.js
-
-      - name: Update floating version tags
-        run: |
-          git config user.name github-actions[bot]
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-          git tag -f "v${{ needs.release-please.outputs.major }}" "${{ needs.release-please.outputs.tag_name }}"
-          git tag -f "v${{ needs.release-please.outputs.major }}.${{ needs.release-please.outputs.minor }}" "${{ needs.release-please.outputs.tag_name }}"
-          git push origin -f "v${{ needs.release-please.outputs.major }}" "v${{ needs.release-please.outputs.major }}.${{ needs.release-please.outputs.minor }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          skip-github-release: true
 
   auto-release:
     needs: release-please

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,8 @@ jobs:
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          # Auto-release verifies, merges, and publishes release PRs below.
+          # Keep Release Please PR-only so follow-up push runs do not try a duplicate release.
           skip-github-release: true
 
   auto-release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,10 @@ jobs:
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          # Auto-release verifies, merges, and publishes release PRs below.
-          # Keep Release Please PR-only so follow-up push runs do not try a duplicate release.
+          # Release Please only creates/updates release PRs here. The auto-release job below
+          # verifies the release PR before merging, then creates the GitHub release and
+          # floating tags from the merged manifest/changelog. Without this flag, the push
+          # created by that merge makes Release Please try to publish the same release too.
           skip-github-release: true
 
   auto-release:

--- a/src/release-workflow.test.ts
+++ b/src/release-workflow.test.ts
@@ -54,7 +54,9 @@ describe("release workflow", () => {
     expect(releaseWorkflow).toContain(
       "if: needs.release-please.outputs.prs_created == 'true'",
     );
-    expect(releaseWorkflow).toContain("skip-github-release: true");
+    expect(releaseWorkflow).toMatch(
+      /uses:\s*googleapis\/release-please-action@v4[\s\S]*?with:[\s\S]*?skip-github-release:\s*true/,
+    );
     expect(releaseWorkflow).toContain("gh pr merge \"$number\" --merge --delete-branch");
     expect(releaseWorkflow).toContain("gh release create \"$tag\"");
     expect(releaseWorkflow).toContain("git push origin -f \"v$major\" \"v$major.$minor\"");

--- a/src/release-workflow.test.ts
+++ b/src/release-workflow.test.ts
@@ -54,6 +54,7 @@ describe("release workflow", () => {
     expect(releaseWorkflow).toContain(
       "if: needs.release-please.outputs.prs_created == 'true'",
     );
+    expect(releaseWorkflow).toContain("skip-github-release: true");
     expect(releaseWorkflow).toContain("gh pr merge \"$number\" --merge --delete-branch");
     expect(releaseWorkflow).toContain("gh release create \"$tag\"");
     expect(releaseWorkflow).toContain("git push origin -f \"v$major\" \"v$major.$minor\"");

--- a/src/release-workflow.test.ts
+++ b/src/release-workflow.test.ts
@@ -65,6 +65,9 @@ describe("release workflow", () => {
     expect(releaseWorkflow).toContain("Release notes for $tag were empty or malformed.");
     expect(releaseWorkflow).toContain("Existing release tag $tag points to");
     expect(releaseWorkflow).not.toContain("jq ");
+    expect(releaseWorkflow).not.toMatch(/\n  verify-release:\n/);
+    expect(releaseWorkflow).not.toContain("needs.release-please.outputs.tag_name");
+    expect(releaseWorkflow).not.toContain("needs.release-please.outputs.release_created");
   });
 
   it("documents that releases publish automatically after merges to main", () => {


### PR DESCRIPTION
## Summary
- set Release Please to skip direct GitHub release creation
- keep the auto-release job as the single publisher for releases and floating tags
- add a workflow contract assertion for PR-only Release Please behavior

## Verification
- npm test -- --runTestsByPath src/release-workflow.test.ts
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release workflow yaml ok"'
- npm run lint
- git diff --check

## Context
After PR #19 merged, Release Please tried to create the GitHub release directly on the follow-up push and failed with `Resource not accessible by integration`. This workflow now leaves release publishing to the auto-release job.