### PR TITLE
fix: mark auto release PRs tagged

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,6 +122,7 @@ jobs:
           set -euo pipefail
 
           merge_sha="${{ steps.merge.outputs.merge_sha }}"
+          number="${{ steps.release-pr.outputs.number }}"
           version=$(
             git show "$merge_sha:.release-please-manifest.json" |
               node -e '
@@ -176,3 +177,4 @@ jobs:
           git tag -f "v$major" "$merge_sha"
           git tag -f "v$major.$minor" "$merge_sha"
           git push origin -f "v$major" "v$major.$minor"
+          gh pr edit "$number" --remove-label "autorelease: pending" --add-label "autorelease: tagged"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,5 +185,13 @@ jobs:
           git tag -f "v$major" "$merge_sha"
           git tag -f "v$major.$minor" "$merge_sha"
           git push origin -f "v$major" "v$major.$minor"
-          gh pr view "$number" --json number >/dev/null
-          gh pr edit "$number" --remove-label "$pending_label" --add-label "$tagged_label"
+
+          if ! gh pr view "$number" --json number >/dev/null 2>&1; then
+            echo "Cannot verify release PR #$number before updating labels." >&2
+            exit 1
+          fi
+
+          if ! gh pr edit "$number" --remove-label "$pending_label" --add-label "$tagged_label"; then
+            echo "Failed to update release PR #$number labels." >&2
+            exit 1
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,8 @@ jobs:
 
           merge_sha="${{ steps.merge.outputs.merge_sha }}"
           number="${{ steps.release-pr.outputs.number }}"
+          pending_label="autorelease: pending"
+          tagged_label="autorelease: tagged"
 
           if [ -z "$number" ] || [[ ! "$number" =~ ^[0-9]+$ ]]; then
             echo "Cannot update release PR labels; invalid PR number: $number" >&2
@@ -183,4 +185,5 @@ jobs:
           git tag -f "v$major" "$merge_sha"
           git tag -f "v$major.$minor" "$merge_sha"
           git push origin -f "v$major" "v$major.$minor"
-          gh pr edit "$number" --remove-label "autorelease: pending" --add-label "autorelease: tagged"
+          gh pr view "$number" --json number >/dev/null
+          gh pr edit "$number" --remove-label "$pending_label" --add-label "$tagged_label"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,8 +126,8 @@ jobs:
           pending_label="autorelease: pending"
           tagged_label="autorelease: tagged"
 
-          if [ -z "$number" ] || [[ ! "$number" =~ ^[0-9]+$ ]]; then
-            echo "Cannot update release PR labels; invalid PR number: $number" >&2
+          if [ -z "$number" ] || [[ ! "$number" =~ ^[0-9]{1,10}$ ]]; then
+            echo "Cannot update release PR labels for ${{ github.repository }}; invalid PR number: $number" >&2
             exit 1
           fi
 
@@ -192,6 +192,6 @@ jobs:
           fi
 
           if ! gh pr edit "$number" --remove-label "$pending_label" --add-label "$tagged_label"; then
-            echo "Failed to update release PR #$number labels." >&2
+            echo "Failed to replace '$pending_label' with '$tagged_label' on release PR #$number." >&2
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,12 @@ jobs:
 
           merge_sha="${{ steps.merge.outputs.merge_sha }}"
           number="${{ steps.release-pr.outputs.number }}"
+
+          if [ -z "$number" ] || [[ ! "$number" =~ ^[0-9]+$ ]]; then
+            echo "Cannot update release PR labels; invalid PR number: $number" >&2
+            exit 1
+          fi
+
           version=$(
             git show "$merge_sha:.release-please-manifest.json" |
               node -e '

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,8 +128,7 @@ jobs:
           pending_label="$RELEASE_PENDING_LABEL"
           tagged_label="$RELEASE_TAGGED_LABEL"
 
-          # Bound the syntactic check before the current-repo existence check below.
-          if [ -z "$number" ] || [[ ! "$number" =~ ^[0-9]{1,10}$ ]]; then
+          if [ -z "$number" ] || [[ ! "$number" =~ ^[0-9]+$ ]]; then
             echo "Cannot update release PR labels for ${{ github.repository }}; invalid PR number: $number" >&2
             exit 1
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,8 @@ jobs:
       issues: write
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      RELEASE_PENDING_LABEL: "autorelease: pending"
+      RELEASE_TAGGED_LABEL: "autorelease: tagged"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -123,9 +125,10 @@ jobs:
 
           merge_sha="${{ steps.merge.outputs.merge_sha }}"
           number="${{ steps.release-pr.outputs.number }}"
-          pending_label="autorelease: pending"
-          tagged_label="autorelease: tagged"
+          pending_label="$RELEASE_PENDING_LABEL"
+          tagged_label="$RELEASE_TAGGED_LABEL"
 
+          # Bound the syntactic check before the current-repo existence check below.
           if [ -z "$number" ] || [[ ! "$number" =~ ^[0-9]{1,10}$ ]]; then
             echo "Cannot update release PR labels for ${{ github.repository }}; invalid PR number: $number" >&2
             exit 1
@@ -191,7 +194,14 @@ jobs:
             exit 1
           fi
 
-          if ! gh pr edit "$number" --remove-label "$pending_label" --add-label "$tagged_label"; then
-            echo "Failed to replace '$pending_label' with '$tagged_label' on release PR #$number." >&2
+          label_action="add '$tagged_label'"
+          label_args=(--add-label "$tagged_label")
+          if gh pr view "$number" --json labels --template '{{range .labels}}{{.name}}{{"\n"}}{{end}}' | grep -Fxq "$pending_label"; then
+            label_action="remove '$pending_label' and add '$tagged_label'"
+            label_args=(--remove-label "$pending_label" "${label_args[@]}")
+          fi
+
+          if ! gh pr edit "$number" "${label_args[@]}"; then
+            echo "Failed to $label_action on release PR #$number." >&2
             exit 1
           fi

--- a/src/release-workflow.test.ts
+++ b/src/release-workflow.test.ts
@@ -67,7 +67,7 @@ describe("release workflow", () => {
     expect(releaseWorkflow).toContain(
       "Cannot verify release PR #$number before updating labels.",
     );
-    expect(releaseWorkflow).toContain("[[ ! \"$number\" =~ ^[0-9]{1,10}$ ]]");
+    expect(releaseWorkflow).toContain("[[ ! \"$number\" =~ ^[0-9]+$ ]]");
     expect(releaseWorkflow).toContain(
       "Cannot update release PR labels for ${{ github.repository }}; invalid PR number: $number",
     );

--- a/src/release-workflow.test.ts
+++ b/src/release-workflow.test.ts
@@ -60,6 +60,9 @@ describe("release workflow", () => {
     expect(releaseWorkflow).toContain("gh pr merge \"$number\" --merge --delete-branch");
     expect(releaseWorkflow).toContain("gh release create \"$tag\"");
     expect(releaseWorkflow).toContain("git push origin -f \"v$major\" \"v$major.$minor\"");
+    expect(releaseWorkflow).toContain(
+      "gh pr edit \"$number\" --remove-label \"autorelease: pending\" --add-label \"autorelease: tagged\"",
+    );
     expect(releaseWorkflow).toContain("[[ ! \"$number\" =~ ^[0-9]+$ ]]");
     expect(releaseWorkflow).toContain("set -euo pipefail");
     expect(releaseWorkflow).toContain("Release notes for $tag were empty or malformed.");

--- a/src/release-workflow.test.ts
+++ b/src/release-workflow.test.ts
@@ -60,8 +60,10 @@ describe("release workflow", () => {
     expect(releaseWorkflow).toContain("gh pr merge \"$number\" --merge --delete-branch");
     expect(releaseWorkflow).toContain("gh release create \"$tag\"");
     expect(releaseWorkflow).toContain("git push origin -f \"v$major\" \"v$major.$minor\"");
-    expect(releaseWorkflow).toContain("pending_label=\"autorelease: pending\"");
-    expect(releaseWorkflow).toContain("tagged_label=\"autorelease: tagged\"");
+    expect(releaseWorkflow).toContain('RELEASE_PENDING_LABEL: "autorelease: pending"');
+    expect(releaseWorkflow).toContain('RELEASE_TAGGED_LABEL: "autorelease: tagged"');
+    expect(releaseWorkflow).toContain("pending_label=\"$RELEASE_PENDING_LABEL\"");
+    expect(releaseWorkflow).toContain("tagged_label=\"$RELEASE_TAGGED_LABEL\"");
     expect(releaseWorkflow).toContain(
       "Cannot verify release PR #$number before updating labels.",
     );
@@ -70,7 +72,18 @@ describe("release workflow", () => {
       "Cannot update release PR labels for ${{ github.repository }}; invalid PR number: $number",
     );
     expect(releaseWorkflow).toContain(
-      "Failed to replace '$pending_label' with '$tagged_label' on release PR #$number.",
+      "label_action=\"add '$tagged_label'\"",
+    );
+    expect(releaseWorkflow).toContain(
+      "label_action=\"remove '$pending_label' and add '$tagged_label'\"",
+    );
+    expect(releaseWorkflow).toContain(
+      "Failed to $label_action on release PR #$number.",
+    );
+    expect(releaseWorkflow).toContain("label_args=(--add-label \"$tagged_label\")");
+    expect(releaseWorkflow).toContain("grep -Fxq \"$pending_label\"");
+    expect(releaseWorkflow).toContain(
+      "label_args=(--remove-label \"$pending_label\" \"${label_args[@]}\")",
     );
     expect(releaseWorkflow).toContain("set -euo pipefail");
     expect(releaseWorkflow).toContain("Release notes for $tag were empty or malformed.");

--- a/src/release-workflow.test.ts
+++ b/src/release-workflow.test.ts
@@ -65,12 +65,12 @@ describe("release workflow", () => {
     expect(releaseWorkflow).toContain(
       "Cannot verify release PR #$number before updating labels.",
     );
+    expect(releaseWorkflow).toContain("[[ ! \"$number\" =~ ^[0-9]{1,10}$ ]]");
     expect(releaseWorkflow).toContain(
-      "Failed to update release PR #$number labels.",
+      "Cannot update release PR labels for ${{ github.repository }}; invalid PR number: $number",
     );
-    expect(releaseWorkflow).toContain("[[ ! \"$number\" =~ ^[0-9]+$ ]]");
     expect(releaseWorkflow).toContain(
-      "Cannot update release PR labels; invalid PR number: $number",
+      "Failed to replace '$pending_label' with '$tagged_label' on release PR #$number.",
     );
     expect(releaseWorkflow).toContain("set -euo pipefail");
     expect(releaseWorkflow).toContain("Release notes for $tag were empty or malformed.");

--- a/src/release-workflow.test.ts
+++ b/src/release-workflow.test.ts
@@ -64,6 +64,9 @@ describe("release workflow", () => {
       "gh pr edit \"$number\" --remove-label \"autorelease: pending\" --add-label \"autorelease: tagged\"",
     );
     expect(releaseWorkflow).toContain("[[ ! \"$number\" =~ ^[0-9]+$ ]]");
+    expect(releaseWorkflow).toContain(
+      "Cannot update release PR labels; invalid PR number: $number",
+    );
     expect(releaseWorkflow).toContain("set -euo pipefail");
     expect(releaseWorkflow).toContain("Release notes for $tag were empty or malformed.");
     expect(releaseWorkflow).toContain("Existing release tag $tag points to");

--- a/src/release-workflow.test.ts
+++ b/src/release-workflow.test.ts
@@ -63,10 +63,10 @@ describe("release workflow", () => {
     expect(releaseWorkflow).toContain("pending_label=\"autorelease: pending\"");
     expect(releaseWorkflow).toContain("tagged_label=\"autorelease: tagged\"");
     expect(releaseWorkflow).toContain(
-      "gh pr view \"$number\" --json number >/dev/null",
+      "Cannot verify release PR #$number before updating labels.",
     );
     expect(releaseWorkflow).toContain(
-      "gh pr edit \"$number\" --remove-label \"$pending_label\" --add-label \"$tagged_label\"",
+      "Failed to update release PR #$number labels.",
     );
     expect(releaseWorkflow).toContain("[[ ! \"$number\" =~ ^[0-9]+$ ]]");
     expect(releaseWorkflow).toContain(

--- a/src/release-workflow.test.ts
+++ b/src/release-workflow.test.ts
@@ -60,8 +60,13 @@ describe("release workflow", () => {
     expect(releaseWorkflow).toContain("gh pr merge \"$number\" --merge --delete-branch");
     expect(releaseWorkflow).toContain("gh release create \"$tag\"");
     expect(releaseWorkflow).toContain("git push origin -f \"v$major\" \"v$major.$minor\"");
+    expect(releaseWorkflow).toContain("pending_label=\"autorelease: pending\"");
+    expect(releaseWorkflow).toContain("tagged_label=\"autorelease: tagged\"");
     expect(releaseWorkflow).toContain(
-      "gh pr edit \"$number\" --remove-label \"autorelease: pending\" --add-label \"autorelease: tagged\"",
+      "gh pr view \"$number\" --json number >/dev/null",
+    );
+    expect(releaseWorkflow).toContain(
+      "gh pr edit \"$number\" --remove-label \"$pending_label\" --add-label \"$tagged_label\"",
     );
     expect(releaseWorkflow).toContain("[[ ! \"$number\" =~ ^[0-9]+$ ]]");
     expect(releaseWorkflow).toContain(


### PR DESCRIPTION
## Summary
- update auto-release to mark the merged Release Please PR as `autorelease: tagged` after publishing
- add a workflow contract assertion so future changes keep that label transition

## Verification
- npm test -- --runTestsByPath src/release-workflow.test.ts
- npm run lint
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release.yml"); puts "release workflow yaml ok"'
- git diff --check

## Context
After auto-release published v1.2.2, the release PR still had `autorelease: pending`. That stale label makes later Release Please runs treat the merged release PR as outstanding.
