### PR TITLE
Repo polish: community surface, llms.txt, bundled chat skill

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: [antongulin]
+custom: ["https://www.anton.qa"]

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug report
+about: Something in Robin isn't working as expected
+title: ""
+labels: bug
+---
+
+**What happened**
+A clear description of the bug.
+
+**Expected**
+What you expected Robin to do.
+
+**Reproduce**
+1. Provider / `LLM_MODEL` used (e.g. `openrouter/free`):
+2. Workflow trigger (PR open, `/robin`, `/summary`):
+3. Steps:
+
+**Logs**
+From the **Actions** tab, open the failed run and paste the relevant output.
+Do **not** paste secrets or API keys.
+
+**Environment**
+- Robin ref pinned (`@main`, `@v1`, SHA):
+- Public or private repo:
+- Hosted or self-hosted runner:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Docs & setup
+    url: https://robinreview.dev
+    about: Setup, providers, and troubleshooting before filing an issue.
+  - name: Security report
+    url: https://github.com/antongulin/robin/security/advisories/new
+    about: Report a vulnerability privately (see SECURITY.md).

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature request
+about: Suggest an improvement to Robin
+title: ""
+labels: enhancement
+---
+
+**Problem**
+What are you trying to do that Robin makes hard or impossible today?
+
+**Proposed solution**
+What you'd like Robin to do.
+
+**Alternatives**
+Anything you've tried or considered.
+
+**Scope check**
+Robin's core promise is $0, bring-your-own-key, runs-in-your-repo. Does this fit that, or
+does it require a hosted service / paid tier?

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+**What & why**
+Briefly: what this changes and the reason.
+
+**Type**
+- [ ] Bug fix
+- [ ] Feature
+- [ ] Docs
+- [ ] Refactor / chore
+
+**Verification**
+- [ ] `npm run lint`
+- [ ] `npm test`
+- [ ] `npm run build` (run before committing — `dist/index.js` is the published bundle)
+
+**Notes**
+Breaking change? Migration needed? Anything reviewers should focus on?

--- a/README.md
+++ b/README.md
@@ -205,9 +205,11 @@ Focused change. Main risk: timeout errors are not handled clearly.
 
 ## Robin in your editor
 
-The one-line installer also drops a small **companion skill** into your coding agent
-(Claude Code's `~/.claude/skills/robin`, when present). It ships with Robin — there's
-nothing separate to install. Once it's there, you can say things like:
+The one-line installer also installs a small **companion skill** into every coding agent
+on your machine (Claude Code, Cursor, Copilot, Windsurf, …) via the cross-platform
+[skills CLI](https://skills.sh) — `npx skills add https://github.com/antongulin/robin --all --global`. It
+ships with Robin; there's nothing separate to sign up for. (Skip it with `ROBIN_SKILL=0`,
+or install it by hand with that command.) Once it's there, you can say things like:
 
 > "review this PR with Robin" · "robin this PR" · "fix the Robin feedback and merge"
 

--- a/README.md
+++ b/README.md
@@ -203,6 +203,19 @@ Focused change. Main risk: timeout errors are not handled clearly.
 **1 (`src/example.ts:24`)** — Retries exist but timeout failures lack context.
 ```
 
+## Robin in your editor
+
+The one-line installer also drops a small **companion skill** into your coding agent
+(Claude Code's `~/.claude/skills/robin`, when present). It ships with Robin — there's
+nothing separate to install. Once it's there, you can say things like:
+
+> "review this PR with Robin" · "robin this PR" · "fix the Robin feedback and merge"
+
+…and the agent drives a bounded review → fix → re-review → merge loop: it waits for
+Robin's review, fixes only the findings it can verify (skipping noise from weaker free
+models), replies to each comment, resolves threads, and merges when green — capped at
+five passes. Source: [skills/robin/SKILL.md](skills/robin/SKILL.md).
+
 ## Supported providers
 
 | Provider | `LLM_BASE_URL` | `LLM_MODEL` example |
@@ -261,6 +274,16 @@ Releases and notes are published automatically from [CHANGELOG.md](CHANGELOG.md)
 - [docs/ADVANCED.md](docs/ADVANCED.md) — all settings, strict mode, manual-only reviews, security notes
 - [CONTRIBUTING.md](CONTRIBUTING.md) — run tests and send pull requests
 - [CHANGELOG.md](CHANGELOG.md) — release history
+
+## Support
+
+Robin is free and open source (MIT). If it saves you money on code review, you can help keep it maintained:
+
+- ⭐ Star the repo — it's the cheapest way to help others find it.
+- 💛 [Sponsor the project](https://github.com/sponsors/antongulin) to support ongoing work.
+- 🐛 [Open an issue](https://github.com/antongulin/robin/issues) for bugs or ideas.
+
+Built by [Anton Gulin](https://github.com/antongulin), AI Architect building AI systems, agent workflows, and software automation. Need a custom AI agent, code-review pipeline, or QA automation? Visit [Anton.QA](https://www.anton.qa).
 
 ## Development
 

--- a/docs/repo-publishing/github-metadata.md
+++ b/docs/repo-publishing/github-metadata.md
@@ -1,0 +1,50 @@
+# Robin — GitHub Metadata Plan
+
+> All `gh` commands here are **review-gated** — run after approval only.
+
+## Current (at audit)
+
+- **Description:** "Robin - free AI code reviews for every PR. BYOK, works with OpenRouter free tier. Auto-reviews on open, /robin or /review on demand. No quotas." (good, < 350 chars)
+- **Homepage:** https://www.robinreview.dev ✓
+- **Topics (19):** ai-code-review, artificial-intelligence, automation, bot, byok, ci-cd, claude, code-review, developer-tools, devtools, free, github-actions, llm, open-source, openai, openrouter, pull-request, pull-request-review, robin
+- **Wiki:** enabled but empty · **Discussions:** off · **Issues:** on
+
+## Recommended changes
+
+**Description** — minor tighten to lead with the keyword + the wedge:
+> Free AI code reviews on every pull request. Bring your own key (OpenRouter free tier works), runs in your repo as a GitHub Action — no quotas, no per-seat fees. `/robin` to review.
+
+**Topics** — current set is strong. Optional swap: drop the vague `free`/`devtools`
+duplication, add competitive/discovery terms `coderabbit-alternative`,
+`ai-pr-review`, `code-review-bot` (GitHub cap is 20).
+
+**Disable the empty wiki** (surface hygiene):
+```bash
+# Run after review only
+gh repo edit antongulin/robin --enable-wiki=false
+```
+
+**Optional — enable Discussions** for a free OSS support channel:
+```bash
+# Run after review only
+gh repo edit antongulin/robin --enable-discussions=true
+```
+
+**Description update:**
+```bash
+# Run after review only
+gh repo edit antongulin/robin \
+  --description "Free AI code reviews on every pull request. Bring your own key (OpenRouter free tier works), runs in your repo as a GitHub Action — no quotas, no per-seat fees." \
+  --add-topic coderabbit-alternative --add-topic ai-pr-review --add-topic code-review-bot
+```
+
+## Skill overlay (skills/robin) — only if shipping it as an installable product
+
+- Install: `npx skills add antongulin/robin`
+- Badge: `[![skills.sh](https://skills.sh/b/antongulin/robin)](https://skills.sh/antongulin/robin)`
+- Verify URL: https://skills.sh/antongulin/robin
+- Note: skills.sh is telemetry-driven — the listing appears after a real
+  `npx skills add antongulin/robin`. Run it once post-decision to seed discovery.
+- Open question: the skill lives under `skills/robin/` inside a tool repo. `npx skills add`
+  expects skills at a discoverable path — confirm the installer resolves `skills/robin/`
+  before advertising the install command.

--- a/docs/repo-publishing/github-metadata.md
+++ b/docs/repo-publishing/github-metadata.md
@@ -38,13 +38,12 @@ gh repo edit antongulin/robin \
   --add-topic coderabbit-alternative --add-topic ai-pr-review --add-topic code-review-bot
 ```
 
-## Skill overlay (skills/robin) — only if shipping it as an installable product
+## Skill overlay (skills/robin) — internal companion, auto-installed
 
-- Install: `npx skills add antongulin/robin`
-- Badge: `[![skills.sh](https://skills.sh/b/antongulin/robin)](https://skills.sh/antongulin/robin)`
-- Verify URL: https://skills.sh/antongulin/robin
-- Note: skills.sh is telemetry-driven — the listing appears after a real
-  `npx skills add antongulin/robin`. Run it once post-decision to seed discovery.
-- Open question: the skill lives under `skills/robin/` inside a tool repo. `npx skills add`
-  expects skills at a discoverable path — confirm the installer resolves `skills/robin/`
-  before advertising the install command.
+The skill ships with Robin and installs automatically via the one-line installer (and is
+documented in the README). Not marketed as a standalone skills.sh product.
+
+- Install (all agents, global): `npx skills add https://github.com/antongulin/robin --all --global`
+- Verified: the skills CLI resolves `skills/robin/` from the repo ("Found 1 skill: robin").
+- skills.sh listing is telemetry-driven; it will appear after real installs. No badge needed
+  unless we later decide to promote it as a standalone pack.

--- a/docs/repo-publishing/publish-plan.md
+++ b/docs/repo-publishing/publish-plan.md
@@ -1,0 +1,53 @@
+# Robin — Publish / Improvement Plan
+
+Local edits are safe to draft. Public GitHub metadata changes are **review-gated**.
+
+## Local improvements (I can apply on a branch)
+
+| # | Change | Why | Effort |
+|---|---|---|---|
+| 1 | **`.github/FUNDING.yml`** + README "Support / Services" section + author block | Monetization/support score 3→7; trust signal | S |
+| 2 | **`llms.txt`** at repo root | LLM discoverability 6→8; AI-search citable | S |
+| 3 | **`.github/ISSUE_TEMPLATE/`** (bug + feature) + **`pull_request_template.md`** | Surface hygiene; guides contributions | S |
+| 4 | README **screenshot** of a real Robin review comment (above the fold) | README conversion 8→9 | M (needs an image) |
+| 5 | **`skills/robin/evals/evals.json`** + README skill section | Skill publishing 5→8 — only if the skill ships as a product | M |
+
+Suggested author block (from the brand reference):
+```md
+Built by [Anton Gulin](https://github.com/antongulin), AI Architect building AI
+systems, agent workflows, and software automation. Need a custom AI agent skill or
+automation? Visit [Anton.QA](https://www.anton.qa).
+```
+
+`.github/FUNDING.yml` (fill in real handles before enabling):
+```yml
+github: [antongulin]
+# custom: ["https://www.anton.qa"]
+```
+
+## Review-gated GitHub actions (run after approval only)
+
+1. `gh repo edit antongulin/robin --enable-wiki=false`  — drop the empty wiki
+2. Description + topics update (see `github-metadata.md`)
+3. Optional: `gh repo edit antongulin/robin --enable-discussions=true`
+
+## Decisions (resolved)
+
+- **Skill = internal companion**, not a skills.sh product. It now installs automatically
+  with Robin: the one-line installer drops it into `~/.claude/skills/robin` when Claude
+  Code is present, and the README documents it. No skills.sh badge or separate evals.
+- **Funding: yes** — `.github/FUNDING.yml` points at GitHub Sponsors (`antongulin`) +
+  Anton.QA; README has a Support section. ⚠️ The Sponsor button only renders once you
+  enable GitHub Sponsors on github.com/sponsors/antongulin.
+- **Screenshot:** deferred — Anton will share real Robin review screenshots; add to the
+  README above the fold then.
+
+## Applied (this branch)
+
+- `.github/FUNDING.yml`, `llms.txt`, issue templates + config, `pull_request_template.md`
+- README: "Robin in your editor" (bundled skill) + "Support" (sponsor + Anton.QA author block)
+- `scripts/install.sh`: auto-installs the companion skill (best-effort, Claude Code)
+
+## Not doing (preserve)
+
+No rewrites of README quick-start, security docs, CI, or release automation — all strong.

--- a/docs/repo-publishing/scorecard.md
+++ b/docs/repo-publishing/scorecard.md
@@ -1,0 +1,41 @@
+# Robin — Repo Readiness Scorecard
+
+Generated via the `repo-publishing-system` skill. Repo type: **public tool repo
+(GitHub Action)** with a light **skill overlay** (`skills/robin/`).
+
+State at audit: PUBLIC · v1.4.0 · 2★ · MIT (detected) · homepage robinreview.dev ·
+19 topics · issues on · wiki on (empty) · discussions off · secret scan clean.
+
+## Scores (0–10)
+
+| Area | Score | Evidence / blocker |
+|---|---|---|
+| GitHub SEO / search | **9** | Specific description, 19 topics, homepage set, v1.4.0 release, keyword-rich README. |
+| README conversion | **8** | Strong value prop, one-line install, 3-step setup, provider table, troubleshooting. Missing: a real screenshot of a Robin review. |
+| LLM discoverability | **6** | Structured headings + AGENTS.md + "For AI coding agents" block. **No `llms.txt`.** |
+| Agent readiness | **8** | AGENTS.md with verified commands, do-not-use rules, secrets table, minimal workflow. |
+| Skill publishing (overlay) | **5** | `skills/robin/SKILL.md` valid with references, but **no evals**, not surfaced in README, no skills.sh badge/install path. |
+| Trust / maintenance | **8** | MIT, CHANGELOG, automated releases, SECURITY, CONTRIBUTING, CI self-test. Missing: issue templates. |
+| Monetization / support | **3** | **No author block, no `FUNDING.yml`, no support CTA.** Biggest gap. |
+| Safety / privacy | **9** | No `pull_request_target`, permission-checked commands, base-branch config reads, secret warnings, scan clean. |
+| Positioning / brand fit | **8** | Clear "Robin Hood of code review — free for everyone"; audience and status obvious. |
+| Code completeness / demo | **9** | Working action, 54 tests, CI green, dogfooded on its own PRs, verified installer. |
+| CI/CD safety | **8** | Least-privilege perms (`contents: read`, `pull-requests: write`), release automation, concurrency control. |
+| GitHub surface hygiene | **5** | Issues on (good), but **empty wiki enabled** and **no issue/PR templates**. |
+
+**Overall: 7.5 / 10** — a strong, safe, well-positioned repo. The gaps are
+presentation/community surface, not substance.
+
+## Biggest blockers (highest leverage first)
+
+1. **No support/author path (3).** Add an author block, `.github/FUNDING.yml`, and a
+   small "Support / Services" section. Cheap, high-trust.
+2. **Empty wiki + no templates (5).** Disable the unused wiki; add issue + PR templates.
+3. **Skill not discoverable (5).** Decide: is `skills/robin` a shipped product? If yes,
+   add `evals/evals.json`, a README skill section, and the skills.sh badge.
+4. **No `llms.txt` (6).** Add a machine-readable summary for AI search / agents.
+
+## Not blockers (already strong — preserve)
+
+Security model, CI safety, test coverage, release automation, positioning, README
+quick-start. Do not rewrite these — only additive patches.

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,35 @@
+# Robin
+
+> Free AI code reviews on every pull request. Robin runs as a GitHub Action in your own
+> repository, calls an OpenAI-compatible LLM endpoint you configure (OpenRouter's free
+> tier works), and posts severity-tiered review comments like a teammate. Bring your own
+> key — no quotas, no per-seat fees, no separate service to sign up for.
+
+## What it is
+
+- A GitHub Action, not a hosted bot. The workflow runs in the user's repo and calls the AI URL they configure.
+- Reviews on PR open; `/robin` (or `/review`) on demand; `/summary` for an overview.
+- Findings are tiered High / Medium / Low / Suggestion, each with a confidence signal, posted inline on changed lines plus a summary.
+- Designed to stay robust even when a weak, randomly-routed free model is used: the diff is line-numbered, the prompt is calibrated, and responses are retried with provider fallbacks.
+
+## Setup
+
+- One-line install (writes the workflow): `curl -fsSL https://robinreview.dev/install.sh | bash`
+- Or add `.github/workflows/robin.yml` calling `antongulin/robin/.github/workflows/review.yml@v1`.
+- Three secrets: `LLM_API_KEY`, `LLM_BASE_URL`, `LLM_MODEL`. Free OpenRouter: base `https://openrouter.ai/api/v1`, model `openrouter/free`.
+
+## Key files
+
+- [README.md](README.md): human setup and usage
+- [action.yml](action.yml): action inputs
+- [.github/workflows/review.yml](.github/workflows/review.yml): reusable workflow consumers call
+- [skills/robin/SKILL.md](skills/robin/SKILL.md): companion chat skill — drives a bounded PR review→fix→merge loop from a coding agent
+- [docs/ADVANCED.md](docs/ADVANCED.md): all settings, strict mode, self-hosted runners
+- [AGENTS.md](AGENTS.md): instructions for AI coding agents adding Robin to a repo
+
+## Links
+
+- Site: https://robinreview.dev
+- Repository: https://github.com/antongulin/robin
+- License: MIT
+- Author: Anton Gulin — https://www.anton.qa

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -56,6 +56,25 @@ YAML
   info "Created $WORKFLOW_PATH (ref: ${REF})"
 fi
 
+# Install the companion chat skill so a coding agent can drive Robin's PR review
+# loop from plain chat ("review with Robin"). Best-effort: only when Claude Code's
+# skills dir exists, and never fatal — the GitHub Action works without it.
+install_skill() {
+  local skills_dir="${HOME}/.claude/skills"
+  [ -d "$skills_dir" ] || return 0
+
+  local dest="${skills_dir}/robin"
+  local base="https://raw.githubusercontent.com/antongulin/robin/${REF}/skills/robin"
+  mkdir -p "${dest}/references"
+
+  if curl -fsSL "${base}/SKILL.md" -o "${dest}/SKILL.md" 2>/dev/null; then
+    curl -fsSL "${base}/references/github-pr-api-reference.md" -o "${dest}/references/github-pr-api-reference.md" 2>/dev/null || true
+    curl -fsSL "${base}/references/lessons-learned.md" -o "${dest}/references/lessons-learned.md" 2>/dev/null || true
+    info "Installed the Robin chat skill to ~/.claude/skills/robin (say \"review with Robin\")."
+  fi
+}
+install_skill
+
 cat <<EOF
 
 Next — set three repository secrets (free OpenRouter shown):

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -56,21 +56,25 @@ YAML
   info "Created $WORKFLOW_PATH (ref: ${REF})"
 fi
 
-# Install the companion chat skill so a coding agent can drive Robin's PR review
-# loop from plain chat ("review with Robin"). Best-effort: only when Claude Code's
-# skills dir exists, and never fatal — the GitHub Action works without it.
+# Install the companion chat skill so any coding agent can drive Robin's PR review
+# loop from plain chat ("review with Robin"). Uses the cross-platform skills CLI to
+# install for every detected agent, globally. Best-effort — the GitHub Action works
+# without it. Set ROBIN_SKILL=0 to skip.
 install_skill() {
-  local skills_dir="${HOME}/.claude/skills"
-  [ -d "$skills_dir" ] || return 0
+  [ "${ROBIN_SKILL:-1}" = "0" ] && return 0
 
-  local dest="${skills_dir}/robin"
-  local base="https://raw.githubusercontent.com/antongulin/robin/${REF}/skills/robin"
-  mkdir -p "${dest}/references"
+  if ! command -v npx >/dev/null 2>&1; then
+    warn "Skipping companion skill — Node.js/npx not found."
+    warn "Install it later: npx skills add https://github.com/antongulin/robin --all --global"
+    return 0
+  fi
 
-  if curl -fsSL "${base}/SKILL.md" -o "${dest}/SKILL.md" 2>/dev/null; then
-    curl -fsSL "${base}/references/github-pr-api-reference.md" -o "${dest}/references/github-pr-api-reference.md" 2>/dev/null || true
-    curl -fsSL "${base}/references/lessons-learned.md" -o "${dest}/references/lessons-learned.md" 2>/dev/null || true
-    info "Installed the Robin chat skill to ~/.claude/skills/robin (say \"review with Robin\")."
+  info "Installing the Robin chat skill for all coding agents…"
+  # --agent '*' = every supported agent, --global = user-level (available everywhere).
+  if npx -y skills add https://github.com/antongulin/robin --skill robin --agent '*' --global --yes >/dev/null 2>&1; then
+    info "Robin chat skill installed (all agents). Say \"review with Robin\"."
+  else
+    warn "Couldn't auto-install the skill. Run: npx skills add https://github.com/antongulin/robin --all --global"
   fi
 }
 install_skill


### PR DESCRIPTION
Output of the `repo-publishing-system` audit (scorecard **7.5/10**) plus the safe local wins it recommended. No change to the action's behavior or interface.

## Added
- **`.github/FUNDING.yml`** — GitHub Sponsors (`antongulin`) + Anton.QA. *(Sponsor button renders once Sponsors is enabled on the account.)*
- **README "Support"** section with author block + sponsor/issue CTAs.
- **`llms.txt`** — machine-readable summary for AI search / agents.
- **Issue templates** (bug, feature) + `config.yml` contact links, and a **PR template**.
- **README "Robin in your editor"** — documents the companion chat skill bundled with Robin.
- **`install.sh`** now installs the companion skill across **all** coding agents via the cross-platform skills CLI: `npx skills add https://github.com/antongulin/robin --all --global` (best-effort; skippable with `ROBIN_SKILL=0`; the Action works without it).
- **`docs/repo-publishing/`** — scorecard, GitHub metadata plan, improvement plan.

## Decisions baked in
- Skill is an **internal companion**, auto-installed with Robin for every agent — not a separate skills.sh product.
- Funding **enabled**; README screenshots **deferred** (Anton will share real ones).

## Not in this PR (review-gated GitHub metadata — run after merge/approval)
- `gh repo edit antongulin/robin --enable-wiki=false` (drop the empty wiki)
- Description tighten + topic additions (see `docs/repo-publishing/github-metadata.md`)

## Verification
- skills CLI resolves the repo's skill ("Found 1 skill: robin") via the full GitHub URL form.
- Installer flow-tested (stubbed npx + isolated `HOME`): workflow written, skill install invoked with `--agent '*' --global`, `ROBIN_SKILL=0` skips, zero `.bak`. `bash -n` clean.
- No `src/` changes, so engine/tests untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)