### PR TITLE
docs(config): fix example to reference .github/robin.yml

### DIFF
--- a/.github/robin.yml.example
+++ b/.github/robin.yml.example
@@ -1,4 +1,4 @@
-# Optional repo config (copy to .github/universal-code-reviewer.yml)
+# Optional repo config (copy to .github/robin.yml)
 # Read from the PR base branch. Action inputs override these when explicitly set.
 
 max-diff-size: 25000


### PR DESCRIPTION
**What & why**
The config example told users to copy to `.github/universal-code-reviewer.yml`, but the action's `DEFAULT_CONFIG_FILE` is already `.github/robin.yml` ([repo-config.ts:1](src/repo-config.ts#L1)). Stale comment — fixing it removes the last old-brand live string. No behavior change.

**Type**
- [x] Docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)