### PR TITLE
feat(config): unify max-comments default to 15

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -17,7 +17,7 @@ on:
         description: "Maximum inline review comments. Extra findings stay in the review body."
         required: false
         type: string
-        default: "10"
+        default: "15"
       max-output-tokens:
         description: "Optional maximum tokens for the LLM response. Leave empty to use the provider/model default."
         required: false

--- a/action.yml
+++ b/action.yml
@@ -51,7 +51,7 @@ inputs:
   max-comments:
     description: "Maximum number of inline review comments to post. Extra findings stay in the review body."
     required: false
-    default: "25"
+    default: "15"
   review-on-synchronize:
     description: "Run automatic reviews for pull_request synchronize events, which happen after each new commit pushed to a PR. Set to true only if you want review on every push."
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -1395,16 +1395,15 @@ function getHelpMessage() {
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.REUSABLE_WORKFLOW_MAX_COMMENTS = exports.DEFAULT_ACTION_MAX_COMMENTS = exports.DEFAULT_ACTION_MAX_DIFF_SIZE = exports.DEFAULT_CONFIG_FILE = void 0;
+exports.DEFAULT_MAX_COMMENTS = exports.DEFAULT_ACTION_MAX_DIFF_SIZE = exports.DEFAULT_CONFIG_FILE = void 0;
 exports.parseRepoConfigYaml = parseRepoConfigYaml;
 exports.resolveMaxDiffSize = resolveMaxDiffSize;
 exports.resolveMaxComments = resolveMaxComments;
 exports.resolveJsonResponseMode = resolveJsonResponseMode;
 exports.DEFAULT_CONFIG_FILE = ".github/robin.yml";
 exports.DEFAULT_ACTION_MAX_DIFF_SIZE = 50000;
-exports.DEFAULT_ACTION_MAX_COMMENTS = 25;
-/** Reusable workflow default in `.github/workflows/review.yml` */
-exports.REUSABLE_WORKFLOW_MAX_COMMENTS = 10;
+/** Single default shared by action.yml and the reusable review.yml workflow. */
+exports.DEFAULT_MAX_COMMENTS = 15;
 function parseRepoConfigYaml(text) {
     const config = {};
     let inSkipPaths = false;
@@ -1456,12 +1455,11 @@ function resolveMaxDiffSize(actionInput, repoConfig) {
 }
 function resolveMaxComments(actionInput, repoConfig) {
     const parsed = parseInt(actionInput, 10);
-    const isUnsetOrWorkflowDefault = Number.isFinite(parsed) &&
-        (parsed === exports.DEFAULT_ACTION_MAX_COMMENTS || parsed === exports.REUSABLE_WORKFLOW_MAX_COMMENTS);
-    if (repoConfig?.maxComments !== undefined && isUnsetOrWorkflowDefault) {
+    const isUnset = Number.isFinite(parsed) && parsed === exports.DEFAULT_MAX_COMMENTS;
+    if (repoConfig?.maxComments !== undefined && isUnset) {
         return repoConfig.maxComments;
     }
-    return Number.isFinite(parsed) && parsed >= 0 ? parsed : exports.DEFAULT_ACTION_MAX_COMMENTS;
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : exports.DEFAULT_MAX_COMMENTS;
 }
 function resolveJsonResponseMode(actionInput, repoConfig) {
     if (actionInput === "true")

--- a/src/repo-config.test.ts
+++ b/src/repo-config.test.ts
@@ -1,7 +1,6 @@
 import {
-  DEFAULT_ACTION_MAX_COMMENTS,
+  DEFAULT_MAX_COMMENTS,
   DEFAULT_ACTION_MAX_DIFF_SIZE,
-  REUSABLE_WORKFLOW_MAX_COMMENTS,
   parseRepoConfigYaml,
   resolveJsonResponseMode,
   resolveMaxComments,
@@ -41,18 +40,16 @@ describe("resolveMaxDiffSize", () => {
 describe("resolveMaxComments", () => {
   it("uses repo config when action input is still the default", () => {
     expect(
-      resolveMaxComments(String(DEFAULT_ACTION_MAX_COMMENTS), { maxComments: 8 })
+      resolveMaxComments(String(DEFAULT_MAX_COMMENTS), { maxComments: 8 })
     ).toBe(8);
   });
 
-  it("uses repo config when reusable workflow passes max-comments 10", () => {
-    expect(
-      resolveMaxComments(String(REUSABLE_WORKFLOW_MAX_COMMENTS), { maxComments: 8 })
-    ).toBe(8);
+  it("honors an explicit non-default action input over repo config", () => {
+    expect(resolveMaxComments("5", { maxComments: 8 })).toBe(5);
   });
 
   it("honors max-comments 0 from repo config", () => {
-    expect(resolveMaxComments(String(DEFAULT_ACTION_MAX_COMMENTS), { maxComments: 0 })).toBe(0);
+    expect(resolveMaxComments(String(DEFAULT_MAX_COMMENTS), { maxComments: 0 })).toBe(0);
   });
 });
 

--- a/src/repo-config.ts
+++ b/src/repo-config.ts
@@ -1,8 +1,7 @@
 export const DEFAULT_CONFIG_FILE = ".github/robin.yml";
 export const DEFAULT_ACTION_MAX_DIFF_SIZE = 50000;
-export const DEFAULT_ACTION_MAX_COMMENTS = 25;
-/** Reusable workflow default in `.github/workflows/review.yml` */
-export const REUSABLE_WORKFLOW_MAX_COMMENTS = 10;
+/** Single default shared by action.yml and the reusable review.yml workflow. */
+export const DEFAULT_MAX_COMMENTS = 15;
 
 export interface RepoConfig {
   maxDiffSize?: number;
@@ -72,13 +71,11 @@ export function resolveMaxDiffSize(actionInput: string, repoConfig?: RepoConfig)
 
 export function resolveMaxComments(actionInput: string, repoConfig?: RepoConfig): number {
   const parsed = parseInt(actionInput, 10);
-  const isUnsetOrWorkflowDefault =
-    Number.isFinite(parsed) &&
-    (parsed === DEFAULT_ACTION_MAX_COMMENTS || parsed === REUSABLE_WORKFLOW_MAX_COMMENTS);
-  if (repoConfig?.maxComments !== undefined && isUnsetOrWorkflowDefault) {
+  const isUnset = Number.isFinite(parsed) && parsed === DEFAULT_MAX_COMMENTS;
+  if (repoConfig?.maxComments !== undefined && isUnset) {
     return repoConfig.maxComments;
   }
-  return Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_ACTION_MAX_COMMENTS;
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : DEFAULT_MAX_COMMENTS;
 }
 
 export function resolveJsonResponseMode(actionInput: string, repoConfig?: RepoConfig): boolean {


### PR DESCRIPTION
**What & why**
`action.yml` defaulted `max-comments` to **25**, the reusable `review.yml` to **10**, and `resolveMaxComments` treated *both* as 'unset' sentinels so a repo `.github/robin.yml` could override either. Collapsed to a single `DEFAULT_MAX_COMMENTS = 15` — one constant, one sentinel, same override behavior. (Roadmap Phase 3: pick one, 10–15.)

Common reusable-workflow path goes 10→15; direct-action path 25→15. **Default-value change only — no input added or removed, interface unchanged.**

**Type**
- [x] Refactor / chore (behavior tweak)

**Verification**
- `npm run lint` ✓ · `npm test` → 54/54 ✓ · `npm run build` ✓ (dist rebuilt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)