### PR TITLE
docs: model-robustness design + prompt-testing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,20 @@ The action runs from `dist/index.js`, so source changes that affect runtime beha
 
 Maintainer-only paths (`docs/superpowers/`, `.agents/`) are gitignored so the public repo stays focused on the action and user docs (`README.md`, `docs/ADVANCED.md`, `AGENTS.md`).
 
+## Testing prompt changes
+
+Robin must give good reviews on weak, free, and randomly-routed models, not just strong
+ones (see [Model robustness](docs/ADVANCED.md#model-robustness)). A prompt tweak that
+helps a strong model can quietly regress a weak one, so test against more than one:
+
+- Run the same PR through **at least 2–3 different free models** (e.g. swap `LLM_MODEL`
+  between a few OpenRouter free models, or point `LLM_BASE_URL` at a local Ollama model).
+- Check the failure modes the prompt defends against: are inline comments anchored to the
+  right lines, is severity calibrated (not everything HIGH), does JSON mode still parse,
+  and does the markdown fallback still work when it doesn't?
+- Prefer a real PR with a known mix of issues over a synthetic one — it exercises severity
+  and confidence calibration more honestly.
+
 ## Pull Request Guidelines
 
 - Keep changes focused.

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -215,6 +215,33 @@ If you raise `llm-timeout-ms` above 10 minutes, also raise the job `timeout-minu
 
 The action fetches diffs via the GitHub API. `actions/checkout` is not required unless other steps need local files.
 
+## Model robustness
+
+Robin is built to give good reviews even when the LLM is a weak, free, or
+randomly-routed model (e.g. OpenRouter's free tier). The prompt and parser do the
+heavy lifting so the model doesn't have to. If you change `src/prompts/`, keep these
+constraints in mind — they are why reviews stay usable across models:
+
+- **Line-numbered diff.** The diff sent to the model is annotated with real new-file
+  line numbers (`src/diff-annotate.ts`), and the prompt tells the model to copy those
+  exact numbers. Weak models are bad at counting lines; handing them the numbers keeps
+  inline comments anchored to the right place instead of drifting or being dropped.
+- **Few-shot severity calibration.** The prompt includes worked HIGH/MEDIUM/LOW/
+  SUGGESTION examples plus an explicit rule: *impact ≠ confidence; never inflate
+  severity*. Without calibration, weak models flag everything as HIGH. The examples
+  pin the scale.
+- **`confidence` field.** Each finding carries `high|medium|low` confidence separate
+  from severity. The parser ignores invalid values, and the Robin skill uses confidence
+  to decide how hard to verify a finding before acting on it. Severity orders effort;
+  confidence gates trust.
+- **"You only see the diff" guard.** The prompt reminds the model it sees changed lines
+  only, not the whole file — so it doesn't invent bugs about code it can't see. The
+  companion skill mirrors this: it treats findings as hypotheses to verify, not orders.
+
+The parser (`src/review-parser.ts`) is deliberately forgiving — it normalizes severity,
+drops unparseable findings, and falls back to a markdown review if JSON mode fails — so a
+malformed response from a weak model degrades instead of crashing the run.
+
 ## Security and privacy
 
 PR diffs are sent to **your** configured LLM endpoint.


### PR DESCRIPTION
**What & why**
Closes the Phase 4 docs gap. Two additions, no code change:
- **`docs/ADVANCED.md` → Model robustness:** explains *why* the engine does line-numbered diffs, few-shot severity calibration, the `confidence` field, and the "you only see the diff" guard — so contributors editing `src/prompts/` don't regress weak-model behavior.
- **`CONTRIBUTING.md` → Testing prompt changes:** test new prompts against 2–3 free models, check the specific failure modes (line anchoring, severity calibration, JSON parse + markdown fallback).

**Type**
- [x] Docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)