### PR TITLE
feat!: drop deprecated input aliases (cuts 2.0.0)

### DIFF
--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -49,7 +49,7 @@ jobs:
           llm-api-key: ${{ secrets.LLM_API_KEY }}
           llm-base-url: ${{ secrets.LLM_BASE_URL }}
           model: ${{ secrets.LLM_MODEL }}
-          fail-on-critical: "false"
+          fail-on-high: "false"
 
   command-test:
     if: |

--- a/action.yml
+++ b/action.yml
@@ -14,24 +14,12 @@ inputs:
     description: "API key for your LLM endpoint. Use \"ollama\" for self-hosted Ollama."
     required: false
     default: "ollama"
-  api-key:
-    description: "Alias for llm-api-key"
-    required: false
-    default: ""
   llm-base-url:
     description: "Base URL for OpenAI-compatible API. Examples: https://api.openai.com/v1, http://your-server:11434/v1"
     required: true
-  base-url:
-    description: "Alias for llm-base-url"
-    required: false
-    default: ""
   model:
     description: "Model name to use. Examples: gpt-4o, llama3.2, codellama:13b, or your provider-specific model name."
     required: true
-  fail-on-critical:
-    description: "Deprecated alias for fail-on-high. If true, the action will fail when high severity issues are found."
-    required: false
-    default: "false"
   fail-on-high:
     description: "If true, the action will fail when high severity issues are found."
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -916,10 +916,10 @@ async function run() {
             core.info("No matching trigger found. Skipping.");
             return;
         }
-        const apiKey = core.getInput("llm-api-key") || core.getInput("api-key") || "ollama";
-        const baseUrl = core.getInput("llm-base-url") || core.getInput("base-url") || "";
+        const apiKey = core.getInput("llm-api-key") || "ollama";
+        const baseUrl = core.getInput("llm-base-url") || "";
         const model = core.getInput("model") || "";
-        const failOnHigh = core.getInput("fail-on-high") === "true" || core.getInput("fail-on-critical") === "true";
+        const failOnHigh = core.getInput("fail-on-high") === "true";
         const maxDiffSizeInput = core.getInput("max-diff-size") || "50000";
         const maxCommentsInput = core.getInput("max-comments") || "25";
         const maxOutputTokensInput = core.getInput("max-output-tokens") || "";

--- a/src/main.ts
+++ b/src/main.ts
@@ -111,10 +111,10 @@ async function run(): Promise<void> {
       return;
     }
 
-    const apiKey = core.getInput("llm-api-key") || core.getInput("api-key") || "ollama";
-    const baseUrl = core.getInput("llm-base-url") || core.getInput("base-url") || "";
+    const apiKey = core.getInput("llm-api-key") || "ollama";
+    const baseUrl = core.getInput("llm-base-url") || "";
     const model = core.getInput("model") || "";
-    const failOnHigh = core.getInput("fail-on-high") === "true" || core.getInput("fail-on-critical") === "true";
+    const failOnHigh = core.getInput("fail-on-high") === "true";
     const maxDiffSizeInput = core.getInput("max-diff-size") || "50000";
     const maxCommentsInput = core.getInput("max-comments") || "25";
     const maxOutputTokensInput = core.getInput("max-output-tokens") || "";


### PR DESCRIPTION
**What & why**
Removes the three legacy alias inputs from `action.yml`. The canonical inputs replace them 1:1, and the reusable workflow + templates already use the canonical names.

| Removed alias | Use instead |
|---|---|
| `api-key` | `llm-api-key` |
| `base-url` | `llm-base-url` |
| `fail-on-critical` | `fail-on-high` |

**Breaking?** Yes — but only for anyone calling `uses: antongulin/robin@…` *directly* with an old name. Consumers of the reusable `review.yml` workflow (the documented path, e.g. tps-engine) are **unaffected** — it already uses canonical names ([review.yml:94-95](.github/workflows/review.yml#L94-L95)). This `feat!` triggers release-please to cut **2.0.0**.

**Verification**
- `npm run lint` ✓ · `npm test` → 54/54 ✓ · `npm run build` ✓ (dist rebuilt)
- Self-test dogfood updated `fail-on-critical` → `fail-on-high`
- `grep` for the three aliases in docs/templates/workflows → 0 live references

🤖 Generated with [Claude Code](https://claude.com/claude-code)