### PR TITLE
docs: show clean-pass screenshot in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ Free AI code reviews for every pull request. You bring an API key; Robin reviews
 - A short summary plus inline comments on changed lines
 - Your choice of AI provider — including **free** options
 
+When there's nothing worth flagging, Robin says so instead of inventing nitpicks:
+
+![A clean Robin pass on a pull request — no issues found](docs/assets/robin-review-clean.png)
+
 You are **not** signing up for a separate review bot service. The workflow runs in your repo and calls the AI URL you configure.
 
 ## For AI coding agents


### PR DESCRIPTION
Adds the "No issues found" review capture (already in `docs/assets/`) to the README so it shows both outcomes — Robin flags real issues, and stays quiet when there's nothing worth flagging.

The clean screenshot was captured earlier but never wired into the README; this uses the second asset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)