### PR TITLE
fix(llm): fail fast when OpenRouter auto-router stalls

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ Add `.github/code-reviewer.md` in your repo:
 | `/robin` does nothing | Put `/robin` on the **first** line; you need write access on the repo |
 | Review is very short | PR may be huge — see [docs/ADVANCED.md](docs/ADVANCED.md) (`max-diff-size`) |
 | `Empty response from LLM` | Free routers sometimes return no text — the action retries automatically; comment `/robin` again |
+| `OpenRouter stall` / job runs 15 min with no review | Auto-router hung — action now aborts after 45s with no stream and retries | Watch Actions log for `LLM resolved model` (routing OK); pin `@v2` or `@main` for the fix |
 | `404 Provider returned error` | Normal for `openrouter/free` when one provider is down — the action retries up to 5 times; keep `LLM_MODEL=openrouter/free` |
 
 More fixes: [docs/ADVANCED.md#troubleshooting](docs/ADVANCED.md#troubleshooting)

--- a/dist/index.js
+++ b/dist/index.js
@@ -52,9 +52,11 @@ function hasRequiredPermission(permission, minimumPermission) {
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.DEFAULT_LLM_ROUTER_RETRY_DELAY_MS = exports.DEFAULT_LLM_RETRY_DELAY_MS = exports.DEFAULT_LLM_ROUTER_COMPLETION_ATTEMPTS = exports.DEFAULT_LLM_COMPLETION_ATTEMPTS = exports.DEFAULT_LLM_TIMEOUT_MS = void 0;
+exports.DEFAULT_LLM_ROUTER_RETRY_DELAY_MS = exports.DEFAULT_LLM_RETRY_DELAY_MS = exports.DEFAULT_LLM_ROUTER_COMPLETION_ATTEMPTS = exports.DEFAULT_LLM_COMPLETION_ATTEMPTS = exports.DEFAULT_LLM_ROUTER_FIRST_CHUNK_MS = exports.DEFAULT_LLM_ROUTER_TIMEOUT_MS = exports.DEFAULT_LLM_TIMEOUT_MS = void 0;
 exports.parseLLMTimeout = parseLLMTimeout;
 exports.DEFAULT_LLM_TIMEOUT_MS = 600000; // 10 minutes
+exports.DEFAULT_LLM_ROUTER_TIMEOUT_MS = 120000; // 2 minutes — openrouter/free happy path is ~60-90s
+exports.DEFAULT_LLM_ROUTER_FIRST_CHUNK_MS = 45000; // no SSE = stacked router; fail fast and retry
 exports.DEFAULT_LLM_COMPLETION_ATTEMPTS = 3;
 exports.DEFAULT_LLM_ROUTER_COMPLETION_ATTEMPTS = 5;
 exports.DEFAULT_LLM_RETRY_DELAY_MS = 2000;
@@ -614,22 +616,26 @@ class LLMClient {
     model;
     maxOutputTokens;
     maxAttempts;
+    routerModel;
     constructor(baseUrl, apiKey, model, maxOutputTokens, timeoutMs = config_1.DEFAULT_LLM_TIMEOUT_MS, maxAttempts = config_1.DEFAULT_LLM_COMPLETION_ATTEMPTS) {
-        core.info(`Initializing LLM client: baseUrl=${baseUrl}, model=${model}, timeout=${timeoutMs} ms, maxAttempts=${maxAttempts}`);
-        this.client = new openai_1.OpenAI({
-            baseURL: baseUrl,
-            apiKey: apiKey || "ollama",
-            maxRetries: 3,
-            timeout: timeoutMs,
-        });
         this.model = model;
+        this.routerModel = (0, llm_retry_1.isOpenRouterRouterModel)(model);
         this.maxOutputTokens =
             maxOutputTokens && Number.isFinite(maxOutputTokens) && maxOutputTokens > 0
                 ? maxOutputTokens
                 : undefined;
         this.maxAttempts = (0, llm_retry_1.getLlmCompletionAttemptCount)(maxAttempts, model);
-        if ((0, llm_retry_1.isOpenRouterRouterModel)(model)) {
-            core.info("OpenRouter router model detected — using extra retries and provider fallbacks for rotating free models.");
+        const effectiveTimeoutMs = (0, llm_retry_1.resolveLlmTimeoutMs)(model, timeoutMs);
+        core.info(`Initializing LLM client: baseUrl=${baseUrl}, model=${model}, timeout=${effectiveTimeoutMs} ms, maxAttempts=${this.maxAttempts}`);
+        // ponytail: chatCompletion owns retries; SDK maxRetries × 10-min timeout burned whole job budgets
+        this.client = new openai_1.OpenAI({
+            baseURL: baseUrl,
+            apiKey: apiKey || "ollama",
+            maxRetries: 0,
+            timeout: effectiveTimeoutMs,
+        });
+        if (this.routerModel) {
+            core.info(`OpenRouter router model — ${config_1.DEFAULT_LLM_ROUTER_FIRST_CHUNK_MS / 1000}s first-chunk stall detect, ${effectiveTimeoutMs / 1000}s stream cap, provider fallbacks.`);
         }
     }
     retryContext() {
@@ -641,15 +647,19 @@ class LLMClient {
         for (let attempt = 1; attempt <= this.maxAttempts; attempt++) {
             const useJson = (0, llm_retry_1.shouldUseJsonResponseMode)(attempt, jsonResponseMode);
             try {
-                const response = await this.client.chat.completions.create(this.buildRequest(systemPrompt, userContent, useJson));
-                const content = this.extractMessageContent(response);
-                const resolvedModel = response.model || this.model;
+                core.info(`LLM attempt ${attempt}/${this.maxAttempts}: waiting for provider...`);
+                const request = this.buildRequest(systemPrompt, userContent, useJson);
+                const { content, model: resolvedModel } = this.routerModel
+                    ? await this.streamChatCompletion(request)
+                    : await this.blockingChatCompletion(request);
                 if (content) {
-                    this.logResolvedModel(resolvedModel);
+                    if (!this.routerModel) {
+                        this.logResolvedModel(resolvedModel || this.model);
+                    }
                     return { content, model: resolvedModel };
                 }
-                lastFinishReason = response.choices?.[0]?.finish_reason || "unknown";
-                core.warning(`LLM attempt ${attempt}/${this.maxAttempts}: empty content (finish_reason=${lastFinishReason}${useJson ? ", json mode" : ""})`);
+                lastFinishReason = "empty";
+                core.warning(`LLM attempt ${attempt}/${this.maxAttempts}: empty content${useJson ? " (json mode)" : ""}`);
             }
             catch (error) {
                 lastError = error;
@@ -671,6 +681,64 @@ class LLMClient {
         }
         throw new Error(`Empty response from LLM after ${this.maxAttempts} attempts (finish_reason=${lastFinishReason})`);
     }
+    async blockingChatCompletion(request) {
+        const response = await this.client.chat.completions.create({
+            ...request,
+            stream: false,
+        });
+        return {
+            content: this.extractMessageContent(response),
+            model: response.model || this.model,
+        };
+    }
+    /** Stream so the first SSE chunk (model id) proves OpenRouter routed; abort if none arrives. */
+    async streamChatCompletion(request) {
+        const firstChunkMs = config_1.DEFAULT_LLM_ROUTER_FIRST_CHUNK_MS;
+        const controller = new AbortController();
+        let gotFirstChunk = false;
+        let stallTimer = setTimeout(() => {
+            controller.abort();
+        }, firstChunkMs);
+        const clearStallTimer = () => {
+            if (stallTimer) {
+                clearTimeout(stallTimer);
+                stallTimer = undefined;
+            }
+        };
+        try {
+            const stream = await this.client.chat.completions.create({ ...request, stream: true }, { signal: controller.signal });
+            const parts = [];
+            let resolvedModel = this.model;
+            for await (const chunk of stream) {
+                if (!gotFirstChunk) {
+                    gotFirstChunk = true;
+                    clearStallTimer();
+                    resolvedModel = chunk.model || resolvedModel;
+                    if (chunk.model && chunk.model !== this.model) {
+                        core.info(`LLM resolved model: ${chunk.model} (requested: ${this.model})`);
+                    }
+                    else {
+                        core.info("OpenRouter stream started — provider accepted the request.");
+                    }
+                }
+                const delta = chunk.choices?.[0]?.delta?.content;
+                if (typeof delta === "string" && delta) {
+                    parts.push(delta);
+                }
+                if (chunk.model) {
+                    resolvedModel = chunk.model;
+                }
+            }
+            return { content: parts.join(""), model: resolvedModel };
+        }
+        catch (error) {
+            clearStallTimer();
+            if (!gotFirstChunk) {
+                throw new Error(`OpenRouter stall: no first response within ${firstChunkMs} ms`);
+            }
+            throw error;
+        }
+    }
     buildRequest(systemPrompt, userContent, jsonResponseMode) {
         const request = {
             model: this.model,
@@ -686,7 +754,7 @@ class LLMClient {
         if (jsonResponseMode) {
             request.response_format = { type: "json_object" };
         }
-        if ((0, llm_retry_1.isOpenRouterRouterModel)(this.model)) {
+        if (this.routerModel) {
             // OpenRouter extension: try other providers when the first free route 404s.
             request.provider = { allow_fallbacks: true };
         }
@@ -725,6 +793,7 @@ exports.LLMClient = LLMClient;
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
+exports.resolveLlmTimeoutMs = resolveLlmTimeoutMs;
 exports.isOpenRouterRouterModel = isOpenRouterRouterModel;
 exports.isOpenRouterProviderError = isOpenRouterProviderError;
 exports.isRetriableLlmError = isRetriableLlmError;
@@ -734,6 +803,11 @@ exports.getLlmCompletionAttemptCount = getLlmCompletionAttemptCount;
 exports.delayMs = delayMs;
 const config_1 = __nccwpck_require__(4008);
 /** OpenRouter routers (e.g. openrouter/free) pick models dynamically — no secret updates needed. */
+function resolveLlmTimeoutMs(model, timeoutMs) {
+    if (timeoutMs !== config_1.DEFAULT_LLM_TIMEOUT_MS)
+        return timeoutMs;
+    return isOpenRouterRouterModel(model) ? config_1.DEFAULT_LLM_ROUTER_TIMEOUT_MS : timeoutMs;
+}
 function isOpenRouterRouterModel(model) {
     if (!model)
         return false;
@@ -774,7 +848,8 @@ function isRetriableLlmError(error, context = {}) {
         message.includes("socket hang up") ||
         message.includes("rate limit") ||
         message.includes("overloaded") ||
-        message.includes("empty response from llm"));
+        message.includes("empty response from llm") ||
+        message.includes("openrouter stall"));
 }
 function shouldUseJsonResponseMode(attempt, jsonResponseMode) {
     return jsonResponseMode && attempt === 1;

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -277,8 +277,9 @@ No daily quota from this action. Real limits:
 | `Input required: model` | Missing secret | Add `LLM_MODEL` |
 | `Input required: llm-base-url` | Missing secret | Add `LLM_BASE_URL` |
 | `Empty response from LLM` | Free/unstable model returned no text | Action retries with backoff; comment `/review` again |
+| `OpenRouter stall: no first response` | Auto-router hung before picking a provider | Action retries every 45s (up to 5×); check Actions log for `LLM resolved model` — that line means routing worked |
 | `404 Provider returned error` | OpenRouter free route missed one provider | Keep `LLM_MODEL=openrouter/free` — action retries (5×) with provider fallbacks; no secret updates when models rotate |
-| `Request timed out` | Large PR or slow free model | Lower `max-diff-size` or raise `llm-timeout-ms` |
+| `Request timed out` | Large PR or slow free model | Lower `max-diff-size` or raise `llm-timeout-ms` (router models default to 2 min per attempt) |
 | `Resource not accessible by integration` | Missing permissions | Add `pull-requests: write` |
 | Slash command ignored | Wrong format or permission | `/review` as first line; need write access |
 | Shallow review | Small model or truncated diff | Stronger model or higher `max-diff-size` |

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,6 @@
 export const DEFAULT_LLM_TIMEOUT_MS = 600000; // 10 minutes
+export const DEFAULT_LLM_ROUTER_TIMEOUT_MS = 120000; // 2 minutes — openrouter/free happy path is ~60-90s
+export const DEFAULT_LLM_ROUTER_FIRST_CHUNK_MS = 45000; // no SSE = stacked router; fail fast and retry
 export const DEFAULT_LLM_COMPLETION_ATTEMPTS = 3;
 export const DEFAULT_LLM_ROUTER_COMPLETION_ATTEMPTS = 5;
 export const DEFAULT_LLM_RETRY_DELAY_MS = 2000;

--- a/src/llm-client.ts
+++ b/src/llm-client.ts
@@ -1,11 +1,16 @@
 import { OpenAI } from "openai";
-import { DEFAULT_LLM_COMPLETION_ATTEMPTS, DEFAULT_LLM_TIMEOUT_MS } from "./config";
+import {
+  DEFAULT_LLM_COMPLETION_ATTEMPTS,
+  DEFAULT_LLM_ROUTER_FIRST_CHUNK_MS,
+  DEFAULT_LLM_TIMEOUT_MS,
+} from "./config";
 import {
   computeRetryDelayMs,
   delayMs,
   getLlmCompletionAttemptCount,
   isOpenRouterRouterModel,
   isRetriableLlmError,
+  resolveLlmTimeoutMs,
   shouldUseJsonResponseMode,
 } from "./llm-retry";
 import * as core from "@actions/core";
@@ -20,6 +25,7 @@ export class LLMClient {
   private model: string;
   private maxOutputTokens?: number;
   private maxAttempts: number;
+  private routerModel: boolean;
 
   constructor(
     baseUrl: string,
@@ -29,26 +35,30 @@ export class LLMClient {
     timeoutMs = DEFAULT_LLM_TIMEOUT_MS,
     maxAttempts = DEFAULT_LLM_COMPLETION_ATTEMPTS
   ) {
-    core.info(
-      `Initializing LLM client: baseUrl=${baseUrl}, model=${model}, timeout=${timeoutMs} ms, maxAttempts=${maxAttempts}`
-    );
-
-    this.client = new OpenAI({
-      baseURL: baseUrl,
-      apiKey: apiKey || "ollama",
-      maxRetries: 3,
-      timeout: timeoutMs,
-    });
-
     this.model = model;
+    this.routerModel = isOpenRouterRouterModel(model);
     this.maxOutputTokens =
       maxOutputTokens && Number.isFinite(maxOutputTokens) && maxOutputTokens > 0
         ? maxOutputTokens
         : undefined;
     this.maxAttempts = getLlmCompletionAttemptCount(maxAttempts, model);
-    if (isOpenRouterRouterModel(model)) {
+    const effectiveTimeoutMs = resolveLlmTimeoutMs(model, timeoutMs);
+
+    core.info(
+      `Initializing LLM client: baseUrl=${baseUrl}, model=${model}, timeout=${effectiveTimeoutMs} ms, maxAttempts=${this.maxAttempts}`
+    );
+
+    // ponytail: chatCompletion owns retries; SDK maxRetries × 10-min timeout burned whole job budgets
+    this.client = new OpenAI({
+      baseURL: baseUrl,
+      apiKey: apiKey || "ollama",
+      maxRetries: 0,
+      timeout: effectiveTimeoutMs,
+    });
+
+    if (this.routerModel) {
       core.info(
-        "OpenRouter router model detected — using extra retries and provider fallbacks for rotating free models."
+        `OpenRouter router model — ${DEFAULT_LLM_ROUTER_FIRST_CHUNK_MS / 1000}s first-chunk stall detect, ${effectiveTimeoutMs / 1000}s stream cap, provider fallbacks.`
       );
     }
   }
@@ -69,20 +79,22 @@ export class LLMClient {
       const useJson = shouldUseJsonResponseMode(attempt, jsonResponseMode);
 
       try {
-        const response = await this.client.chat.completions.create(
-          this.buildRequest(systemPrompt, userContent, useJson)
-        );
-        const content = this.extractMessageContent(response);
-        const resolvedModel = response.model || this.model;
+        core.info(`LLM attempt ${attempt}/${this.maxAttempts}: waiting for provider...`);
+        const request = this.buildRequest(systemPrompt, userContent, useJson);
+        const { content, model: resolvedModel } = this.routerModel
+          ? await this.streamChatCompletion(request)
+          : await this.blockingChatCompletion(request);
 
         if (content) {
-          this.logResolvedModel(resolvedModel);
+          if (!this.routerModel) {
+            this.logResolvedModel(resolvedModel || this.model);
+          }
           return { content, model: resolvedModel };
         }
 
-        lastFinishReason = response.choices?.[0]?.finish_reason || "unknown";
+        lastFinishReason = "empty";
         core.warning(
-          `LLM attempt ${attempt}/${this.maxAttempts}: empty content (finish_reason=${lastFinishReason}${useJson ? ", json mode" : ""})`
+          `LLM attempt ${attempt}/${this.maxAttempts}: empty content${useJson ? " (json mode)" : ""}`
         );
       } catch (error) {
         lastError = error;
@@ -113,12 +125,83 @@ export class LLMClient {
     );
   }
 
+  private async blockingChatCompletion(
+    request: OpenAI.Chat.Completions.ChatCompletionCreateParams
+  ): Promise<ChatCompletionResult> {
+    const response = await this.client.chat.completions.create({
+      ...request,
+      stream: false,
+    });
+    return {
+      content: this.extractMessageContent(response),
+      model: response.model || this.model,
+    };
+  }
+
+  /** Stream so the first SSE chunk (model id) proves OpenRouter routed; abort if none arrives. */
+  private async streamChatCompletion(
+    request: OpenAI.Chat.Completions.ChatCompletionCreateParams
+  ): Promise<ChatCompletionResult> {
+    const firstChunkMs = DEFAULT_LLM_ROUTER_FIRST_CHUNK_MS;
+    const controller = new AbortController();
+    let gotFirstChunk = false;
+    let stallTimer: ReturnType<typeof setTimeout> | undefined = setTimeout(() => {
+      controller.abort();
+    }, firstChunkMs);
+
+    const clearStallTimer = () => {
+      if (stallTimer) {
+        clearTimeout(stallTimer);
+        stallTimer = undefined;
+      }
+    };
+
+    try {
+      const stream = await this.client.chat.completions.create(
+        { ...request, stream: true },
+        { signal: controller.signal }
+      );
+
+      const parts: string[] = [];
+      let resolvedModel = this.model;
+
+      for await (const chunk of stream) {
+        if (!gotFirstChunk) {
+          gotFirstChunk = true;
+          clearStallTimer();
+          resolvedModel = chunk.model || resolvedModel;
+          if (chunk.model && chunk.model !== this.model) {
+            core.info(`LLM resolved model: ${chunk.model} (requested: ${this.model})`);
+          } else {
+            core.info("OpenRouter stream started — provider accepted the request.");
+          }
+        }
+
+        const delta = chunk.choices?.[0]?.delta?.content;
+        if (typeof delta === "string" && delta) {
+          parts.push(delta);
+        }
+        if (chunk.model) {
+          resolvedModel = chunk.model;
+        }
+      }
+
+      return { content: parts.join(""), model: resolvedModel };
+    } catch (error) {
+      clearStallTimer();
+      if (!gotFirstChunk) {
+        throw new Error(`OpenRouter stall: no first response within ${firstChunkMs} ms`);
+      }
+      throw error;
+    }
+  }
+
   private buildRequest(
     systemPrompt: string,
     userContent: string,
     jsonResponseMode: boolean
-  ): OpenAI.Chat.Completions.ChatCompletionCreateParamsNonStreaming {
-    const request: OpenAI.Chat.Completions.ChatCompletionCreateParamsNonStreaming = {
+  ): OpenAI.Chat.Completions.ChatCompletionCreateParams {
+    const request: OpenAI.Chat.Completions.ChatCompletionCreateParams = {
       model: this.model,
       messages: [
         { role: "system", content: systemPrompt },
@@ -135,9 +218,9 @@ export class LLMClient {
       request.response_format = { type: "json_object" };
     }
 
-    if (isOpenRouterRouterModel(this.model)) {
+    if (this.routerModel) {
       // OpenRouter extension: try other providers when the first free route 404s.
-      (request as OpenAI.Chat.Completions.ChatCompletionCreateParamsNonStreaming & {
+      (request as OpenAI.Chat.Completions.ChatCompletionCreateParams & {
         provider?: { allow_fallbacks: boolean };
       }).provider = { allow_fallbacks: true };
     }

--- a/src/llm-retry.test.ts
+++ b/src/llm-retry.test.ts
@@ -3,13 +3,29 @@ import {
   getLlmCompletionAttemptCount,
   isOpenRouterRouterModel,
   isRetriableLlmError,
+  resolveLlmTimeoutMs,
   shouldUseJsonResponseMode,
 } from "./llm-retry";
 import {
   DEFAULT_LLM_COMPLETION_ATTEMPTS,
   DEFAULT_LLM_ROUTER_COMPLETION_ATTEMPTS,
   DEFAULT_LLM_ROUTER_RETRY_DELAY_MS,
+  DEFAULT_LLM_ROUTER_TIMEOUT_MS,
+  DEFAULT_LLM_TIMEOUT_MS,
 } from "./config";
+
+describe("resolveLlmTimeoutMs", () => {
+  it("shortens the default timeout for OpenRouter routers", () => {
+    expect(resolveLlmTimeoutMs("openrouter/free", DEFAULT_LLM_TIMEOUT_MS)).toBe(
+      DEFAULT_LLM_ROUTER_TIMEOUT_MS
+    );
+    expect(resolveLlmTimeoutMs("gpt-4o", DEFAULT_LLM_TIMEOUT_MS)).toBe(DEFAULT_LLM_TIMEOUT_MS);
+  });
+
+  it("keeps an explicit consumer override", () => {
+    expect(resolveLlmTimeoutMs("openrouter/free", 300000)).toBe(300000);
+  });
+});
 
 describe("isOpenRouterRouterModel", () => {
   it("detects OpenRouter free and auto routers", () => {
@@ -33,6 +49,11 @@ describe("isRetriableLlmError", () => {
   it("retries network and timeout messages", () => {
     expect(isRetriableLlmError(new Error("Request timed out"))).toBe(true);
     expect(isRetriableLlmError(new Error("ECONNRESET"))).toBe(true);
+    expect(
+      isRetriableLlmError(new Error("OpenRouter stall: no first response within 45000 ms"), {
+        model: "openrouter/free",
+      })
+    ).toBe(true);
   });
 
   it("retries OpenRouter provider 404s for router models", () => {

--- a/src/llm-retry.ts
+++ b/src/llm-retry.ts
@@ -3,6 +3,8 @@ import {
   DEFAULT_LLM_RETRY_DELAY_MS,
   DEFAULT_LLM_ROUTER_COMPLETION_ATTEMPTS,
   DEFAULT_LLM_ROUTER_RETRY_DELAY_MS,
+  DEFAULT_LLM_ROUTER_TIMEOUT_MS,
+  DEFAULT_LLM_TIMEOUT_MS,
 } from "./config";
 
 export interface LlmRetryContext {
@@ -10,6 +12,11 @@ export interface LlmRetryContext {
 }
 
 /** OpenRouter routers (e.g. openrouter/free) pick models dynamically — no secret updates needed. */
+export function resolveLlmTimeoutMs(model: string | undefined, timeoutMs: number): number {
+  if (timeoutMs !== DEFAULT_LLM_TIMEOUT_MS) return timeoutMs;
+  return isOpenRouterRouterModel(model) ? DEFAULT_LLM_ROUTER_TIMEOUT_MS : timeoutMs;
+}
+
 export function isOpenRouterRouterModel(model: string | undefined): boolean {
   if (!model) return false;
   const normalized = model.trim().toLowerCase();
@@ -57,7 +64,8 @@ export function isRetriableLlmError(error: unknown, context: LlmRetryContext = {
     message.includes("socket hang up") ||
     message.includes("rate limit") ||
     message.includes("overloaded") ||
-    message.includes("empty response from llm")
+    message.includes("empty response from llm") ||
+    message.includes("openrouter stall")
   );
 }
 


### PR DESCRIPTION
## Summary
- Stream `openrouter/free` (and other router models) so the first SSE chunk logs the resolved model immediately — proof routing worked
- Abort after **45s** with no first chunk (`OpenRouter stall`) and retry up to 5× with provider fallbacks
- Cap each attempt at **2 min** (when `llm-timeout-ms` is default) and set SDK `maxRetries: 0` so hung routes no longer burn the full 15 min job budget
- Document stall detection in README and ADVANCED troubleshooting

## Problem
When OpenRouter's auto-router hung, Robin waited on a 10 min timeout × SDK retries until GitHub killed the job at 15 min — often with only `Getting full code review...` in the logs and no PR comment.

## Test plan
- [x] `npm test` (56 passed)
- [x] `npm run build`
- [ ] Merge and verify a tps-engine PR review logs `LLM resolved model` within ~1 min on happy path
- [ ] Verify stalled OpenRouter retries within ~45s per attempt instead of 15 min silence


Made with [Cursor](https://cursor.com)