### PR TITLE
fix(llm): update PR status on stalls, retries, and job cancel

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -617,9 +617,11 @@ class LLMClient {
     maxOutputTokens;
     maxAttempts;
     routerModel;
-    constructor(baseUrl, apiKey, model, maxOutputTokens, timeoutMs = config_1.DEFAULT_LLM_TIMEOUT_MS, maxAttempts = config_1.DEFAULT_LLM_COMPLETION_ATTEMPTS) {
+    onProgress;
+    constructor(baseUrl, apiKey, model, maxOutputTokens, timeoutMs = config_1.DEFAULT_LLM_TIMEOUT_MS, maxAttempts = config_1.DEFAULT_LLM_COMPLETION_ATTEMPTS, onProgress) {
         this.model = model;
         this.routerModel = (0, llm_retry_1.isOpenRouterRouterModel)(model);
+        this.onProgress = onProgress;
         this.maxOutputTokens =
             maxOutputTokens && Number.isFinite(maxOutputTokens) && maxOutputTokens > 0
                 ? maxOutputTokens
@@ -641,6 +643,11 @@ class LLMClient {
     retryContext() {
         return { model: this.model };
     }
+    async progress(detail) {
+        if (this.onProgress) {
+            await this.onProgress(detail);
+        }
+    }
     async chatCompletion(systemPrompt, userContent, jsonResponseMode = false) {
         let lastFinishReason = "unknown";
         let lastError;
@@ -648,6 +655,7 @@ class LLMClient {
             const useJson = (0, llm_retry_1.shouldUseJsonResponseMode)(attempt, jsonResponseMode);
             try {
                 core.info(`LLM attempt ${attempt}/${this.maxAttempts}: waiting for provider...`);
+                await this.progress(`Waiting for provider (attempt ${attempt}/${this.maxAttempts})…`);
                 const request = this.buildRequest(systemPrompt, userContent, useJson);
                 const { content, model: resolvedModel } = this.routerModel
                     ? await this.streamChatCompletion(request)
@@ -671,7 +679,9 @@ class LLMClient {
             }
             if (attempt < this.maxAttempts) {
                 const waitMs = (0, llm_retry_1.computeRetryDelayMs)(attempt, this.retryContext());
+                const reason = lastError instanceof Error ? lastError.message : "empty response";
                 core.info(`Retrying LLM request in ${waitMs} ms (attempt ${attempt + 1}/${this.maxAttempts})...`);
+                await this.progress(`Attempt ${attempt} did not succeed (${reason}). Retrying in ${Math.round(waitMs / 1000)}s…`);
                 await (0, llm_retry_1.delayMs)(waitMs);
             }
         }
@@ -696,6 +706,7 @@ class LLMClient {
         const firstChunkMs = config_1.DEFAULT_LLM_ROUTER_FIRST_CHUNK_MS;
         const controller = new AbortController();
         let gotFirstChunk = false;
+        // ponytail: timer starts before create() so a hung TCP/connect also fails at firstChunkMs
         let stallTimer = setTimeout(() => {
             controller.abort();
         }, firstChunkMs);
@@ -716,9 +727,11 @@ class LLMClient {
                     resolvedModel = chunk.model || resolvedModel;
                     if (chunk.model && chunk.model !== this.model) {
                         core.info(`LLM resolved model: ${chunk.model} (requested: ${this.model})`);
+                        await this.progress(`Routed to \`${chunk.model}\` — generating review…`);
                     }
                     else {
                         core.info("OpenRouter stream started — provider accepted the request.");
+                        await this.progress("Provider accepted the request — generating review…");
                     }
                 }
                 const delta = chunk.choices?.[0]?.delta?.content;
@@ -734,7 +747,7 @@ class LLMClient {
         catch (error) {
             clearStallTimer();
             if (!gotFirstChunk) {
-                throw new Error(`OpenRouter stall: no first response within ${firstChunkMs} ms`);
+                throw (0, llm_retry_1.openRouterStallError)(firstChunkMs);
             }
             throw error;
         }
@@ -801,6 +814,7 @@ exports.shouldUseJsonResponseMode = shouldUseJsonResponseMode;
 exports.computeRetryDelayMs = computeRetryDelayMs;
 exports.getLlmCompletionAttemptCount = getLlmCompletionAttemptCount;
 exports.delayMs = delayMs;
+exports.openRouterStallError = openRouterStallError;
 const config_1 = __nccwpck_require__(4008);
 /** OpenRouter routers (e.g. openrouter/free) pick models dynamically — no secret updates needed. */
 function resolveLlmTimeoutMs(model, timeoutMs) {
@@ -868,6 +882,9 @@ function getLlmCompletionAttemptCount(maxAttempts = config_1.DEFAULT_LLM_COMPLET
 async function delayMs(ms) {
     await new Promise((resolve) => setTimeout(resolve, ms));
 }
+function openRouterStallError(firstChunkMs) {
+    return new Error(`OpenRouter stall: no first response within ${firstChunkMs} ms`);
+}
 //# sourceMappingURL=llm-retry.js.map
 
 /***/ }),
@@ -930,6 +947,13 @@ async function run() {
     let statusRepo = "";
     let statusCommentId;
     let statusCommand = "review";
+    let statusModel = "not configured";
+    let onJobCancelled;
+    registerJobCancelHandler(async () => {
+        if (onJobCancelled) {
+            await onJobCancelled();
+        }
+    });
     try {
         const eventName = github.context.eventName;
         const payload = github.context.payload;
@@ -1011,7 +1035,13 @@ async function run() {
         core.info(`Model: ${model || "(not configured)"}`);
         core.info(`Running /${command} on PR #${prNumber} in ${owner}/${repo}`);
         statusCommand = command === "summary" ? "summary" : "review";
-        statusCommentId = await postStatusComment(octokit, owner, repo, prNumber, command, model || "not configured");
+        statusModel = model || "not configured";
+        statusCommentId = await postStatusComment(octokit, owner, repo, prNumber, command, statusModel);
+        onJobCancelled = async () => {
+            if (octokit && statusCommentId) {
+                await updateStatusComment(octokit, statusOwner, statusRepo, statusCommentId, buildCancelledStatusBody(statusCommand));
+            }
+        };
         if (!baseUrl) {
             throw new Error("Input required and not supplied: llm-base-url");
         }
@@ -1027,6 +1057,7 @@ async function run() {
         const diff = await gitUtils.getPullRequestDiff(owner, repo, prNumber);
         if (!diff || diff.trim().length === 0) {
             core.warning("No diff found for this PR.");
+            await updateStatusComment(octokit, owner, repo, statusCommentId, buildFailedStatusBody("No diff found for this pull request.", statusCommand));
             return;
         }
         const diffFiles = (0, diff_filter_1.splitDiffIntoFiles)(diff);
@@ -1042,6 +1073,7 @@ async function run() {
         const reviewDiff = filteredDiff.trim() ? filteredDiff : diff;
         if (!reviewDiff.trim()) {
             core.warning("No reviewable diff remained after filtering skipped paths.");
+            await updateStatusComment(octokit, owner, repo, statusCommentId, buildFailedStatusBody("No reviewable diff remained after filtering skipped paths.", statusCommand));
             return;
         }
         const truncatedDiff = reviewDiff.length > maxDiffSize
@@ -1051,7 +1083,9 @@ async function run() {
         const reviewInstructions = command === "review"
             ? await loadReviewInstructions(octokit, gitUtils, owner, repo, prNumber, inlineReviewInstructions, reviewInstructionsFile, baseRef)
             : "";
-        const llm = new llm_client_1.LLMClient(baseUrl, apiKey, model, maxOutputTokens, llmTimeoutMs);
+        const llm = new llm_client_1.LLMClient(baseUrl, apiKey, model, maxOutputTokens, llmTimeoutMs, undefined, async (detail) => {
+            await updateStatusComment(octokit, owner, repo, statusCommentId, buildProgressStatusBody(detail, statusCommand, statusModel));
+        });
         const useJsonMode = command === "review" && jsonResponseMode;
         let reviewText;
         if (command === "summary") {
@@ -1077,6 +1111,7 @@ async function run() {
             let findings = parsedReview.findings;
             if ((0, review_retry_1.shouldRetryStructuredReview)(findings, parsedReview.usedJson)) {
                 core.warning("Structured review parse was empty; retrying once with JSON-only instructions.");
+                await updateStatusComment(octokit, owner, repo, statusCommentId, buildProgressStatusBody("First pass returned no parseable findings — retrying with JSON-only instructions…", statusCommand, statusModel));
                 const retryText = (await runReview(llm, truncatedDiff, `${reviewInstructions}\n\nReturn ONLY a single valid JSON object. Do not use markdown.`, true)).content;
                 parsedReview = review_parser_1.ReviewParser.parseDetailed(retryText);
                 findings = parsedReview.findings;
@@ -1089,6 +1124,7 @@ async function run() {
                 core.setFailed(`Found ${findings.high.length} high severity issue(s). Failing check.`);
             }
         }
+        onJobCancelled = undefined;
         core.info("Done.");
     }
     catch (error) {
@@ -1097,6 +1133,9 @@ async function run() {
             await updateStatusComment(octokit, statusOwner, statusRepo, statusCommentId, buildFailedStatusBody(message, statusCommand));
         }
         core.setFailed(message);
+    }
+    finally {
+        onJobCancelled = undefined;
     }
 }
 async function addEyesReaction(octokit, owner, repo, commentId) {
@@ -1198,6 +1237,40 @@ function buildFailedStatusBody(errorMessage, command) {
         "",
         "Free model routes drop sometimes — comment `/robin` to try again. (No secrets are included in this message.)",
     ].join("\n");
+}
+function buildProgressStatusBody(detail, command, model) {
+    return [
+        "## :bow_and_arrow: Robin",
+        "",
+        ":hourglass_flowing_sand: Still working on this pull request.",
+        "",
+        detail,
+        "",
+        `Mode: ${command === "summary" ? "summary" : "code review"}`,
+        `Model: ${model}`,
+    ].join("\n");
+}
+function buildCancelledStatusBody(command) {
+    return [
+        "## :bow_and_arrow: Robin",
+        "",
+        `:warning: The ${command === "summary" ? "summary" : "review"} was interrupted before it finished.`,
+        "",
+        "This usually means the GitHub Actions job was cancelled or hit its time limit while waiting on the model.",
+        "",
+        "Comment `/robin` to run again.",
+    ].join("\n");
+}
+function registerJobCancelHandler(onCancel) {
+    let handled = false;
+    const run = () => {
+        if (handled)
+            return;
+        handled = true;
+        void onCancel().finally(() => process.exit(143));
+    };
+    process.once("SIGTERM", run);
+    process.once("SIGINT", run);
 }
 async function loadRepoConfig(octokit, gitUtils, owner, repo, prNumber, configFile, baseRef) {
     const filePath = configFile.trim();

--- a/dist/index.js
+++ b/dist/index.js
@@ -644,8 +644,13 @@ class LLMClient {
         return { model: this.model };
     }
     async progress(detail) {
-        if (this.onProgress) {
+        if (!this.onProgress)
+            return;
+        try {
             await this.onProgress(detail);
+        }
+        catch (error) {
+            core.warning(`LLM progress update failed (non-fatal): ${error}`);
         }
     }
     async chatCompletion(systemPrompt, userContent, jsonResponseMode = false) {
@@ -949,11 +954,6 @@ async function run() {
     let statusCommand = "review";
     let statusModel = "not configured";
     let onJobCancelled;
-    registerJobCancelHandler(async () => {
-        if (onJobCancelled) {
-            await onJobCancelled();
-        }
-    });
     try {
         const eventName = github.context.eventName;
         const payload = github.context.payload;
@@ -1042,6 +1042,11 @@ async function run() {
                 await updateStatusComment(octokit, statusOwner, statusRepo, statusCommentId, buildCancelledStatusBody(statusCommand));
             }
         };
+        registerJobCancelHandler(async () => {
+            if (onJobCancelled) {
+                await onJobCancelled();
+            }
+        });
         if (!baseUrl) {
             throw new Error("Input required and not supplied: llm-base-url");
         }

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -277,7 +277,8 @@ No daily quota from this action. Real limits:
 | `Input required: model` | Missing secret | Add `LLM_MODEL` |
 | `Input required: llm-base-url` | Missing secret | Add `LLM_BASE_URL` |
 | `Empty response from LLM` | Free/unstable model returned no text | Action retries with backoff; comment `/review` again |
-| `OpenRouter stall: no first response` | Auto-router hung before picking a provider | Action retries every 45s (up to 5×); check Actions log for `LLM resolved model` — that line means routing worked |
+| `OpenRouter stall: no first response` | Auto-router hung before picking a provider | Action retries every 45s (up to 5×); PR status comment updates each attempt |
+| Job cancelled / 15 min with no review | Hung LLM or concurrency cancel while waiting | Status comment should say interrupted — comment `/robin` again; pin `@v2.0.4`+ for stall detect |
 | `404 Provider returned error` | OpenRouter free route missed one provider | Keep `LLM_MODEL=openrouter/free` — action retries (5×) with provider fallbacks; no secret updates when models rotate |
 | `Request timed out` | Large PR or slow free model | Lower `max-diff-size` or raise `llm-timeout-ms` (router models default to 2 min per attempt) |
 | `Resource not accessible by integration` | Missing permissions | Add `pull-requests: write` |

--- a/src/llm-client.ts
+++ b/src/llm-client.ts
@@ -10,6 +10,7 @@ import {
   getLlmCompletionAttemptCount,
   isOpenRouterRouterModel,
   isRetriableLlmError,
+  openRouterStallError,
   resolveLlmTimeoutMs,
   shouldUseJsonResponseMode,
 } from "./llm-retry";
@@ -20,12 +21,15 @@ export interface ChatCompletionResult {
   model?: string;
 }
 
+export type LlmProgressHandler = (detail: string) => void | Promise<void>;
+
 export class LLMClient {
   private client: OpenAI;
   private model: string;
   private maxOutputTokens?: number;
   private maxAttempts: number;
   private routerModel: boolean;
+  private onProgress?: LlmProgressHandler;
 
   constructor(
     baseUrl: string,
@@ -33,10 +37,12 @@ export class LLMClient {
     model: string,
     maxOutputTokens?: number,
     timeoutMs = DEFAULT_LLM_TIMEOUT_MS,
-    maxAttempts = DEFAULT_LLM_COMPLETION_ATTEMPTS
+    maxAttempts = DEFAULT_LLM_COMPLETION_ATTEMPTS,
+    onProgress?: LlmProgressHandler
   ) {
     this.model = model;
     this.routerModel = isOpenRouterRouterModel(model);
+    this.onProgress = onProgress;
     this.maxOutputTokens =
       maxOutputTokens && Number.isFinite(maxOutputTokens) && maxOutputTokens > 0
         ? maxOutputTokens
@@ -67,6 +73,12 @@ export class LLMClient {
     return { model: this.model };
   }
 
+  private async progress(detail: string): Promise<void> {
+    if (this.onProgress) {
+      await this.onProgress(detail);
+    }
+  }
+
   async chatCompletion(
     systemPrompt: string,
     userContent: string,
@@ -80,6 +92,9 @@ export class LLMClient {
 
       try {
         core.info(`LLM attempt ${attempt}/${this.maxAttempts}: waiting for provider...`);
+        await this.progress(
+          `Waiting for provider (attempt ${attempt}/${this.maxAttempts})…`
+        );
         const request = this.buildRequest(systemPrompt, userContent, useJson);
         const { content, model: resolvedModel } = this.routerModel
           ? await this.streamChatCompletion(request)
@@ -108,7 +123,11 @@ export class LLMClient {
 
       if (attempt < this.maxAttempts) {
         const waitMs = computeRetryDelayMs(attempt, this.retryContext());
+        const reason = lastError instanceof Error ? lastError.message : "empty response";
         core.info(`Retrying LLM request in ${waitMs} ms (attempt ${attempt + 1}/${this.maxAttempts})...`);
+        await this.progress(
+          `Attempt ${attempt} did not succeed (${reason}). Retrying in ${Math.round(waitMs / 1000)}s…`
+        );
         await delayMs(waitMs);
       }
     }
@@ -145,6 +164,7 @@ export class LLMClient {
     const firstChunkMs = DEFAULT_LLM_ROUTER_FIRST_CHUNK_MS;
     const controller = new AbortController();
     let gotFirstChunk = false;
+    // ponytail: timer starts before create() so a hung TCP/connect also fails at firstChunkMs
     let stallTimer: ReturnType<typeof setTimeout> | undefined = setTimeout(() => {
       controller.abort();
     }, firstChunkMs);
@@ -172,8 +192,10 @@ export class LLMClient {
           resolvedModel = chunk.model || resolvedModel;
           if (chunk.model && chunk.model !== this.model) {
             core.info(`LLM resolved model: ${chunk.model} (requested: ${this.model})`);
+            await this.progress(`Routed to \`${chunk.model}\` — generating review…`);
           } else {
             core.info("OpenRouter stream started — provider accepted the request.");
+            await this.progress("Provider accepted the request — generating review…");
           }
         }
 
@@ -190,7 +212,7 @@ export class LLMClient {
     } catch (error) {
       clearStallTimer();
       if (!gotFirstChunk) {
-        throw new Error(`OpenRouter stall: no first response within ${firstChunkMs} ms`);
+        throw openRouterStallError(firstChunkMs);
       }
       throw error;
     }

--- a/src/llm-client.ts
+++ b/src/llm-client.ts
@@ -74,8 +74,11 @@ export class LLMClient {
   }
 
   private async progress(detail: string): Promise<void> {
-    if (this.onProgress) {
+    if (!this.onProgress) return;
+    try {
       await this.onProgress(detail);
+    } catch (error) {
+      core.warning(`LLM progress update failed (non-fatal): ${error}`);
     }
   }
 

--- a/src/llm-retry.test.ts
+++ b/src/llm-retry.test.ts
@@ -3,6 +3,7 @@ import {
   getLlmCompletionAttemptCount,
   isOpenRouterRouterModel,
   isRetriableLlmError,
+  openRouterStallError,
   resolveLlmTimeoutMs,
   shouldUseJsonResponseMode,
 } from "./llm-retry";
@@ -13,6 +14,14 @@ import {
   DEFAULT_LLM_ROUTER_TIMEOUT_MS,
   DEFAULT_LLM_TIMEOUT_MS,
 } from "./config";
+
+describe("openRouterStallError", () => {
+  it("produces a retriable stall message", () => {
+    const error = openRouterStallError(45000);
+    expect(error.message).toContain("OpenRouter stall");
+    expect(isRetriableLlmError(error, { model: "openrouter/free" })).toBe(true);
+  });
+});
 
 describe("resolveLlmTimeoutMs", () => {
   it("shortens the default timeout for OpenRouter routers", () => {

--- a/src/llm-retry.ts
+++ b/src/llm-retry.ts
@@ -100,3 +100,7 @@ export function getLlmCompletionAttemptCount(
 export async function delayMs(ms: number): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, ms));
 }
+
+export function openRouterStallError(firstChunkMs: number): Error {
+  return new Error(`OpenRouter stall: no first response within ${firstChunkMs} ms`);
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,6 +25,14 @@ async function run(): Promise<void> {
   let statusRepo = "";
   let statusCommentId: number | undefined;
   let statusCommand: "review" | "summary" = "review";
+  let statusModel = "not configured";
+  let onJobCancelled: (() => Promise<void>) | undefined;
+
+  registerJobCancelHandler(async () => {
+    if (onJobCancelled) {
+      await onJobCancelled();
+    }
+  });
 
   try {
     const eventName = github.context.eventName;
@@ -133,7 +141,19 @@ async function run(): Promise<void> {
 
     core.info(`Running /${command} on PR #${prNumber} in ${owner}/${repo}`);
     statusCommand = command === "summary" ? "summary" : "review";
-    statusCommentId = await postStatusComment(octokit, owner, repo, prNumber, command, model || "not configured");
+    statusModel = model || "not configured";
+    statusCommentId = await postStatusComment(octokit, owner, repo, prNumber, command, statusModel);
+    onJobCancelled = async () => {
+      if (octokit && statusCommentId) {
+        await updateStatusComment(
+          octokit,
+          statusOwner,
+          statusRepo,
+          statusCommentId,
+          buildCancelledStatusBody(statusCommand)
+        );
+      }
+    };
 
     if (!baseUrl) {
       throw new Error("Input required and not supplied: llm-base-url");
@@ -161,6 +181,13 @@ async function run(): Promise<void> {
     
     if (!diff || diff.trim().length === 0) {
       core.warning("No diff found for this PR.");
+      await updateStatusComment(
+        octokit,
+        owner,
+        repo,
+        statusCommentId,
+        buildFailedStatusBody("No diff found for this pull request.", statusCommand)
+      );
       return;
     }
 
@@ -185,6 +212,13 @@ async function run(): Promise<void> {
     const reviewDiff = filteredDiff.trim() ? filteredDiff : diff;
     if (!reviewDiff.trim()) {
       core.warning("No reviewable diff remained after filtering skipped paths.");
+      await updateStatusComment(
+        octokit,
+        owner,
+        repo,
+        statusCommentId,
+        buildFailedStatusBody("No reviewable diff remained after filtering skipped paths.", statusCommand)
+      );
       return;
     }
 
@@ -208,7 +242,23 @@ async function run(): Promise<void> {
       )
       : "";
 
-    const llm = new LLMClient(baseUrl, apiKey, model, maxOutputTokens, llmTimeoutMs);
+    const llm = new LLMClient(
+      baseUrl,
+      apiKey,
+      model,
+      maxOutputTokens,
+      llmTimeoutMs,
+      undefined,
+      async (detail) => {
+        await updateStatusComment(
+          octokit!,
+          owner,
+          repo,
+          statusCommentId,
+          buildProgressStatusBody(detail, statusCommand, statusModel)
+        );
+      }
+    );
     const useJsonMode = command === "review" && jsonResponseMode;
     
     let reviewText: string;
@@ -235,6 +285,17 @@ async function run(): Promise<void> {
 
       if (shouldRetryStructuredReview(findings, parsedReview.usedJson)) {
         core.warning("Structured review parse was empty; retrying once with JSON-only instructions.");
+        await updateStatusComment(
+          octokit,
+          owner,
+          repo,
+          statusCommentId,
+          buildProgressStatusBody(
+            "First pass returned no parseable findings — retrying with JSON-only instructions…",
+            statusCommand,
+            statusModel
+          )
+        );
         const retryText = (
           await runReview(
             llm,
@@ -258,6 +319,7 @@ async function run(): Promise<void> {
       }
     }
 
+    onJobCancelled = undefined;
     core.info("Done.");
 
   } catch (error) {
@@ -266,6 +328,8 @@ async function run(): Promise<void> {
       await updateStatusComment(octokit, statusOwner, statusRepo, statusCommentId, buildFailedStatusBody(message, statusCommand));
     }
     core.setFailed(message);
+  } finally {
+    onJobCancelled = undefined;
   }
 }
 
@@ -391,6 +455,46 @@ function buildFailedStatusBody(errorMessage: string, command: "review" | "summar
     "",
     "Free model routes drop sometimes — comment `/robin` to try again. (No secrets are included in this message.)",
   ].join("\n");
+}
+
+function buildProgressStatusBody(
+  detail: string,
+  command: "review" | "summary",
+  model: string
+): string {
+  return [
+    "## :bow_and_arrow: Robin",
+    "",
+    ":hourglass_flowing_sand: Still working on this pull request.",
+    "",
+    detail,
+    "",
+    `Mode: ${command === "summary" ? "summary" : "code review"}`,
+    `Model: ${model}`,
+  ].join("\n");
+}
+
+function buildCancelledStatusBody(command: "review" | "summary"): string {
+  return [
+    "## :bow_and_arrow: Robin",
+    "",
+    `:warning: The ${command === "summary" ? "summary" : "review"} was interrupted before it finished.`,
+    "",
+    "This usually means the GitHub Actions job was cancelled or hit its time limit while waiting on the model.",
+    "",
+    "Comment `/robin` to run again.",
+  ].join("\n");
+}
+
+function registerJobCancelHandler(onCancel: () => Promise<void>): void {
+  let handled = false;
+  const run = () => {
+    if (handled) return;
+    handled = true;
+    void onCancel().finally(() => process.exit(143));
+  };
+  process.once("SIGTERM", run);
+  process.once("SIGINT", run);
 }
 
 async function loadRepoConfig(

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,12 +28,6 @@ async function run(): Promise<void> {
   let statusModel = "not configured";
   let onJobCancelled: (() => Promise<void>) | undefined;
 
-  registerJobCancelHandler(async () => {
-    if (onJobCancelled) {
-      await onJobCancelled();
-    }
-  });
-
   try {
     const eventName = github.context.eventName;
     const payload = github.context.payload;
@@ -154,6 +148,11 @@ async function run(): Promise<void> {
         );
       }
     };
+    registerJobCancelHandler(async () => {
+      if (onJobCancelled) {
+        await onJobCancelled();
+      }
+    });
 
     if (!baseUrl) {
       throw new Error("Input required and not supplied: llm-base-url");


### PR DESCRIPTION
## Summary
- Update the PR status comment during LLM attempts, OpenRouter routing, and retries (no more frozen "On it" for minutes)
- Post failure when there is no diff or nothing reviewable after filters
- Handle `SIGTERM`/`SIGINT` so cancelled or timed-out jobs update the status comment instead of leaving it hanging
- Extract `openRouterStallError()` for consistent stall detection + tests

Builds on v2.0.4 streaming stall detect.

## Test plan
- [x] `npm test` (57 passed)
- [x] `npm run build`
- [ ] Robin self-review on this PR — triage comments before merge
- [ ] Verify on tps-engine after release: stalled run updates comment within ~45s

**Do not merge until review comments are triaged.**


Made with [Cursor](https://cursor.com)