### PR TITLE
fix(ci): keep /robin working for @v1 consumers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,16 +189,19 @@ jobs:
           git push origin -f "v$major" "v$major.$minor"
 
           # v2+ releases do not move v1, but @v1 consumers need the latest 1.x workflow
-          # (including /robin in the issue_comment gate since v1.4.0).
-          latest_v1=$(
-            git tag -l "v1.*" --sort=-v:refname |
-              grep -E "^v1\\.[0-9]+\\.[0-9]+$" |
-              head -1
-          )
-          if [ -n "$latest_v1" ]; then
-            v1_sha=$(git rev-list -n 1 "$latest_v1")
-            git tag -f v1 "$v1_sha"
-            git push origin -f v1
+          # (including /robin in the issue_comment gate since v1.4.0). On a v1.x release
+          # line 189 already moved v1, so only resync for major >= 2.
+          if [ "$major" -ne 1 ]; then
+            latest_v1=$(
+              git tag -l "v1.*" --sort=-v:refname |
+                grep -E "^v1\\.[0-9]+\\.[0-9]+$" |
+                head -1
+            )
+            if [ -n "$latest_v1" ]; then
+              v1_sha=$(git rev-list -n 1 "$latest_v1")
+              git tag -f v1 "$v1_sha"
+              git push origin -f v1
+            fi
           fi
 
           if ! gh pr view "$number" --json number >/dev/null 2>&1; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,6 +188,19 @@ jobs:
           git tag -f "v$major.$minor" "$merge_sha"
           git push origin -f "v$major" "v$major.$minor"
 
+          # v2+ releases do not move v1, but @v1 consumers need the latest 1.x workflow
+          # (including /robin in the issue_comment gate since v1.4.0).
+          latest_v1=$(
+            git tag -l "v1.*" --sort=-v:refname |
+              grep -E "^v1\\.[0-9]+\\.[0-9]+$" |
+              head -1
+          )
+          if [ -n "$latest_v1" ]; then
+            v1_sha=$(git rev-list -n 1 "$latest_v1")
+            git tag -f v1 "$v1_sha"
+            git push origin -f v1
+          fi
+
           if ! gh pr view "$number" --json number >/dev/null 2>&1; then
             echo "Cannot verify release PR #$number before updating labels." >&2
             exit 1

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Add `.github/code-reviewer.md` in your repo:
 | Workflow fails immediately | Check all three secrets exist and the workflow uses `@main` |
 | `Input required: model` or `llm-base-url` | Add missing secrets (Step 2) |
 | Review never appears | Open **Actions** tab → open the failed run → read the error |
-| `/robin` does nothing | Put `/robin` on the **first** line; you need write access on the repo |
+| `/robin` does nothing | Put `/robin` on the **first** line; you need write access on the repo. On `@v1`, pin `@v1.4.0`+ or use `/review` if the tag predates v1.4.0 |
 | Review is very short | PR may be huge — see [docs/ADVANCED.md](docs/ADVANCED.md) (`max-diff-size`) |
 | `Empty response from LLM` | Free routers sometimes return no text — the action retries automatically; comment `/robin` again |
 | `OpenRouter stall` / job runs 15 min with no review | Auto-router hung — action now aborts after 45s with no stream and retries | Watch Actions log for `LLM resolved model` (routing OK); pin `@v2` or `@main` for the fix |

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -174,6 +174,7 @@ jobs:
         contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
         (
           startsWith(github.event.comment.body, '/review') ||
+          startsWith(github.event.comment.body, '/robin') ||
           startsWith(github.event.comment.body, '/summary') ||
           startsWith(github.event.comment.body, '/help')
         )
@@ -211,7 +212,7 @@ If you raise `llm-timeout-ms` above 10 minutes, also raise the job `timeout-minu
 1. PR opened, reopened, or marked ready for review → automatic review.
 2. Status comment appears, then updates when done.
 3. Author pushes fixes → no automatic re-review (by default).
-4. Maintainer comments `/review` for another pass.
+4. Maintainer comments `/robin` or `/review` for another pass.
 
 The action fetches diffs via the GitHub API. `actions/checkout` is not required unless other steps need local files.
 
@@ -282,7 +283,8 @@ No daily quota from this action. Real limits:
 | `404 Provider returned error` | OpenRouter free route missed one provider | Keep `LLM_MODEL=openrouter/free` — action retries (5×) with provider fallbacks; no secret updates when models rotate |
 | `Request timed out` | Large PR or slow free model | Lower `max-diff-size` or raise `llm-timeout-ms` (router models default to 2 min per attempt) |
 | `Resource not accessible by integration` | Missing permissions | Add `pull-requests: write` |
-| Slash command ignored | Wrong format or permission | `/review` as first line; need write access |
+| Slash command ignored | Wrong format or permission | `/robin` or `/review` as first line; need write access |
+| `/robin` does nothing on `@v1` | Stale `v1` tag before v1.4.0 | Use `/review`, pin `@v1.4.0`+, or `@v2`; floating `v1` tracks latest `1.x` on release |
 | Shallow review | Small model or truncated diff | Stronger model or higher `max-diff-size` |
 
 ## Comparison

--- a/src/commands.test.ts
+++ b/src/commands.test.ts
@@ -3,6 +3,8 @@ import { hasRequiredPermission, parseSlashCommand } from "./commands";
 describe("parseSlashCommand", () => {
   it("parses supported commands from the first non-empty line", () => {
     expect(parseSlashCommand("\n  /review please")).toBe("review");
+    expect(parseSlashCommand("/robin")).toBe("review");
+    expect(parseSlashCommand("/ROBIN please")).toBe("review");
     expect(parseSlashCommand("/summary")).toBe("summary");
     expect(parseSlashCommand("/help")).toBe("help");
   });

--- a/src/release-workflow.test.ts
+++ b/src/release-workflow.test.ts
@@ -60,6 +60,7 @@ describe("release workflow", () => {
     expect(releaseWorkflow).toContain("gh pr merge \"$number\" --merge --delete-branch");
     expect(releaseWorkflow).toContain("gh release create \"$tag\"");
     expect(releaseWorkflow).toContain("git push origin -f \"v$major\" \"v$major.$minor\"");
+    expect(releaseWorkflow).toContain('if [ "$major" -ne 1 ]; then');
     expect(releaseWorkflow).toContain('git tag -l "v1.*" --sort=-v:refname');
     expect(releaseWorkflow).toContain("git tag -f v1 \"$v1_sha\"");
     expect(releaseWorkflow).toContain("git push origin -f v1");

--- a/src/release-workflow.test.ts
+++ b/src/release-workflow.test.ts
@@ -60,6 +60,9 @@ describe("release workflow", () => {
     expect(releaseWorkflow).toContain("gh pr merge \"$number\" --merge --delete-branch");
     expect(releaseWorkflow).toContain("gh release create \"$tag\"");
     expect(releaseWorkflow).toContain("git push origin -f \"v$major\" \"v$major.$minor\"");
+    expect(releaseWorkflow).toContain('git tag -l "v1.*" --sort=-v:refname');
+    expect(releaseWorkflow).toContain("git tag -f v1 \"$v1_sha\"");
+    expect(releaseWorkflow).toContain("git push origin -f v1");
     expect(releaseWorkflow).toContain('RELEASE_PENDING_LABEL: "autorelease: pending"');
     expect(releaseWorkflow).toContain('RELEASE_TAGGED_LABEL: "autorelease: tagged"');
     expect(releaseWorkflow).toContain("pending_label=\"$RELEASE_PENDING_LABEL\"");

--- a/src/workflow.test.ts
+++ b/src/workflow.test.ts
@@ -6,9 +6,26 @@ const reviewWorkflow = readFileSync(
   join(repoRoot, ".github", "workflows", "review.yml"),
   "utf8",
 );
+const selfTestWorkflow = readFileSync(
+  join(repoRoot, ".github", "workflows", "self-test.yml"),
+  "utf8",
+);
+const robinTemplate = readFileSync(join(repoRoot, "templates", "robin.yml"), "utf8");
 const readme = readFileSync(join(repoRoot, "README.md"), "utf8");
 
+const slashCommandGate =
+  "startsWith(github.event.comment.body, '/robin')";
+
 describe("reusable review workflow", () => {
+  it.each([
+    ["review.yml", reviewWorkflow],
+    ["self-test.yml", selfTestWorkflow],
+    ["templates/robin.yml", robinTemplate],
+  ])("accepts /robin comment triggers in %s", (_name, workflow) => {
+    expect(workflow).toContain(slashCommandGate);
+    expect(workflow).toContain("startsWith(github.event.comment.body, '/review')");
+  });
+
   it("lets callers choose a GitHub-hosted or self-hosted runner", () => {
     expect(reviewWorkflow).toContain("runner:");
     expect(reviewWorkflow).toContain(


### PR DESCRIPTION
## Summary
- Sync floating `v1` tag to the latest `1.x` release on every publish so `@v1` consumers always get the workflow gate that includes `/robin` (fixed in v1.4.0).
- Add regression tests ensuring `review.yml`, `self-test.yml`, and `templates/robin.yml` all accept `/robin` comment triggers.
- Document `/robin` in the ADVANCED direct-action example and troubleshooting for stale or exact pre-1.4 pins.

## Test plan
- [x] `npm test` (60 passed)
- [ ] Open PR — Robin auto-review should run
- [ ] Comment `/robin` on this PR to verify re-trigger works


Made with [Cursor](https://cursor.com)