### PR TITLE
feat(skill): harden Robin PR-review loop and add version self-check

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,6 +6,9 @@
       "package-name": "robin",
       "include-component-in-tag": false,
       "pull-request-title-pattern": "chore: release ${version}",
+      "extra-files": [
+        { "type": "generic", "path": "skills/robin/SKILL.md" }
+      ],
       "changelog-sections": [
         { "type": "feat", "section": "Features" },
         { "type": "fix", "section": "Bug Fixes" },

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# Robin skill updater — pulls the latest Robin companion skill into every coding
+# agent on this machine (Claude Code, Cursor, Copilot, Windsurf, …).
+#
+#   bash scripts/update.sh
+#
+# It only touches the globally-installed `robin` skill via the cross-platform
+# skills CLI (https://skills.sh) — the same command the installer uses, which
+# knows each agent's skill directory so we don't hard-code any paths here.
+# No sudo, no repo changes. The update applies the next time an agent loads the
+# skill, not to a run already in progress.
+#
+set -euo pipefail
+
+REPO_URL="https://github.com/antongulin/robin"
+
+info() { printf '\033[0;32m🏹 %s\033[0m\n' "$1"; }
+die()  { printf '\033[0;31m🏹 %s\033[0m\n' "$1" >&2; exit 1; }
+
+command -v npx >/dev/null 2>&1 \
+  || die "npx (Node.js) not found — install Node, then re-run, or: npx skills add $REPO_URL --all --global"
+
+info "Updating the Robin skill across all coding agents…"
+# `skills add` is idempotent — re-adding upgrades an existing install in place.
+npx -y skills add "$REPO_URL" --skill robin --agent '*' --global --yes \
+  && info "Done. The new version applies on the next skill run." \
+  || die "Update failed. Try manually: npx skills add $REPO_URL --all --global"

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -19,10 +19,12 @@ info() { printf '\033[0;32m🏹 %s\033[0m\n' "$1"; }
 die()  { printf '\033[0;31m🏹 %s\033[0m\n' "$1" >&2; exit 1; }
 
 command -v npx >/dev/null 2>&1 \
-  || die "npx (Node.js) not found — install Node, then re-run, or: npx skills add $REPO_URL --all --global"
+  || die "npx (Node.js) not found — install Node, then re-run, or: npx -y skills add $REPO_URL --skill robin --agent '*' --global --yes"
 
 info "Updating the Robin skill across all coding agents…"
 # `skills add` is idempotent — re-adding upgrades an existing install in place.
-npx -y skills add "$REPO_URL" --skill robin --agent '*' --global --yes \
-  && info "Done. The new version applies on the next skill run." \
-  || die "Update failed. Try manually: npx skills add $REPO_URL --all --global"
+if npx -y skills add "$REPO_URL" --skill robin --agent '*' --global --yes; then
+  info "Done. The new version applies on the next skill run."
+else
+  die "Update failed. Try manually: npx -y skills add $REPO_URL --skill robin --agent '*' --global --yes"
+fi

--- a/skills/robin/SKILL.md
+++ b/skills/robin/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: robin
+version: 2.0.6 # x-release-please-version
 description: Use when the user mentions Robin for a pull request — "review with Robin", "run Robin", "robin this PR", "create a PR with Robin", "ask Robin to review", "start the Robin loop" — or, more generally, when a GitHub pull request needs review monitoring, reviewer-comment triage, PR feedback fixes, comment replies, unresolved-thread cleanup, or a bounded wait → fix → re-review → merge loop.
 ---
 
@@ -44,16 +45,67 @@ creation, and an extra `/robin` starts a duplicate reviewer run.
 Track an iteration counter, starting at the first Robin review pass. **Run at most 5
 review → fix → re-review passes per PR.**
 
-- Each completed Robin review (auto-triggered or `/robin`) counts as one pass.
-- On reaching pass 5: do **not** request another review. Fix any remaining *verified*
-  bugs from the last pass, reply to and resolve open threads, run the green-light gate,
-  and merge.
+- A pass is one **review → fix → re-review round**, counted once. The auto-triggered
+  review on PR creation starts pass 1; each subsequent fix-and-re-review is the next
+  pass. So a re-review does *not* add a pass on its own — it closes the round its fix
+  opened. Counting rounds (not raw Robin runs) is what keeps the loop from drifting to 6
+  or 7. State the current count each pass ("pass 3 of 5").
+- **A fix push may auto-trigger the re-review for you.** Many repos run Robin on
+  `pull_request: [opened, synchronize]`, so pushing commits starts a fresh review on its
+  own — that run *is* the re-review half of the current pass, not a bonus. When that
+  happens, watch it; do **not** also post `/robin` (that's the duplicate-run mistake).
+  Repos that run Robin only on the `/robin` comment won't auto-trigger — there you
+  request the re-review yourself (step 5).
+- On reaching pass 5: do **not** silently push another fix or request another review —
+  either would start a 6th round. Evaluate the pass-5 review, fix any remaining
+  *verified* bugs, reply to and resolve open threads, then **stop and ask the user** how
+  to proceed (see below) rather than looping further on your own.
 - Stop early the moment a pass is clean and the green-light gate passes — you do not
   need to use all 5.
+
+**At the 5-pass ceiling without a green light, ask the user — don't decide alone.**
+Robin almost always emits *some* feedback (noise included), so a PR can keep drawing new
+low/medium comments forever. Reaching pass 5 without convergence means only the user
+should choose whether to keep spending passes. Present a short status and ask, e.g.:
+
+> Used all 5 Robin passes. Verified issues still open: `<list or "none">`. Noise skipped:
+> `<count>`. I can (a) keep going — but that's past the 5-pass cap, so only if you say so
+> — or (b) stop here and merge as-is. Which?
+
+Frame (a) as an explicit override, not a routine choice: the whole point of the cap is
+that unbounded re-review is the failure mode. Default to **stopping and asking** — never
+auto-loop past 5. The user can also pre-authorize either side up front ("keep going until
+clean, no cap" / "just merge whenever it's green"); honor an explicit instruction like
+that over this default.
 
 Over-reviewing a PR is a failure mode, not thoroughness. Re-running Robin indefinitely
 burns GitHub Actions minutes and free-model calls for diminishing returns. Five passes
 is the ceiling; most PRs converge in one or two.
+
+## 0. Confirm the Skill Is Current (best-effort)
+
+A stale copy of this skill can follow an outdated protocol, so at the start of a run do a
+quick, **non-blocking** version check. You already know your installed version — it's the
+`version:` field in this skill's own frontmatter above. Compare it to the latest release:
+
+```bash
+gh release view --repo antongulin/robin --json tagName -q .tagName 2>/dev/null | sed 's/^v//'
+```
+
+- Up to date, **or the check fails** (offline, rate-limited, `gh` missing) → just proceed.
+  Never block the PR work on this — a failed version check is not a reason to stop.
+- Behind → tell the user (e.g. *"robin skill is v2.0.6, latest is v2.1.0"*) and update
+  **only** with their OK, or immediately if they've pre-authorized ("keep robin up to
+  date"). The installer is cross-agent, so one command updates every coding agent that has
+  it (Claude Code, Cursor, Copilot, Windsurf, …) — don't hunt for per-agent paths yourself:
+
+  ```bash
+  npx -y skills add https://github.com/antongulin/robin --skill robin --agent '*' --global --yes
+  # or the maintained wrapper: bash scripts/update.sh
+  ```
+
+  An update takes effect on the **next** run — the skill executing now is already loaded in
+  context. So finish this PR on the current version; the newer one applies next time.
 
 ## 1. Discover Context
 
@@ -83,14 +135,37 @@ the full `reviewThreads` query and the `resolveReviewThread` mutation.
 
 ## 3. Handle Auto-Triggered Review
 
-When a PR was just created, or no completed Robin result exists yet, wait before
-requesting another review:
+When a PR was just created, or no completed Robin result exists yet, **poll** for a
+result — don't fire one long blind sleep. A healthy Robin run finishes in about a
+minute, often less. Poll roughly every 30s so you notice a new review comment promptly
+and can act on it while it's fresh:
 
 ```bash
-sleep 60
+# poll loop — repeat until a Robin result appears or the escalation threshold hits
+sleep 30
 gh pr view <number> --json comments,reviews,statusCheckRollup
 gh run list --limit 20 --json databaseId,event,status,conclusion,workflowName,createdAt,url,displayTitle,headBranch
 ```
+
+**Escalation threshold (~3 min).** Because a normal run lands in ≈1 min, silence past
+~3 minutes means something is likely wrong — most often a flaky free-model route or an
+unstable provider, occasionally just a slow one. Don't keep sleeping blindly; go look
+at GitHub Actions:
+
+```bash
+gh run view <run-id>                # status of a still-running job — is it stuck?
+gh run view <run-id> --log-failed   # only once it has completed with a failure
+```
+
+Use plain `gh run view` for an `in_progress` run — `--log-failed` returns nothing until
+a run has finished with failed steps, so it only applies to the failure branch below.
+
+- Run still `in_progress` well past ~1 min → a slow/degraded provider. Keep polling at
+  30s, but cap the total wait (about 8–10 min) before treating it as INFRA.
+- Run `completed` with `conclusion: failure`, or a Robin status comment saying it
+  couldn't finish the review → INFRA (step 4). Rerun the failed run before any `/robin`.
+- No Robin run appears at all after ~3 min → auto-trigger likely didn't fire; fall
+  through to the `/robin` fallback below.
 
 Look for any Robin-started signal in PR comments, reviews, or check runs. Do not require
 one exact phrase. Examples:
@@ -181,7 +256,14 @@ git commit -m "fix(pr-feedback): address Robin review comments"
 git push
 ```
 
-Request another review pass — **only if you are below 5 passes**:
+Now get the re-review — but **only if you are below 5 passes**, and mind how the repo
+triggers Robin so you don't start a duplicate run:
+
+- **If the push already auto-triggered Robin** (the common `pull_request:
+  [opened, synchronize]` config — check `gh run list` / PR comments the way step 3 does),
+  that run *is* your re-review. Watch it; do **not** also post `/robin`.
+- **Only if no auto-run appears after the push** (repo runs Robin solely on the `/robin`
+  comment) request one explicitly:
 
 ```bash
 gh pr comment <number> --body "/robin
@@ -241,33 +323,112 @@ Re-query GraphQL review threads. State explicitly:
 If the latest clean pass exists but `reviewDecision` is still `CHANGES_REQUESTED`, treat
 it as stale only when all threads are resolved and checks are green.
 
-## 9. Merge
+**Before merging, handle release notes if the repo publishes them.** This has to happen
+*now*, pre-merge: a squash merge freezes the PR title/body into the commit the release
+tooling reads, and once merged the branch is gone. See the **Release Notes** reference at
+the end of this skill — detect the repo's mechanism and prepare notes before you ask to
+merge.
 
-Only after the green-light gate:
+**When the gate passes, tell the user it's ready and ask before merging.** Merging is
+the one irreversible step here, so don't do it silently. Report the gate summary above
+and ask, e.g. *"PR #123 is green and ready to merge — want me to merge it?"* Wait for a
+yes. The user can pre-authorize this ("merge automatically when it's green"); if they
+have, skip the question and merge.
+
+## 9. Merge and Clean Up
+
+Only after the green-light gate, the release-notes step (if the repo publishes them —
+step 8), **and** the user's go-ahead or their standing pre-authorization.
+
+**Pick the merge method the repo actually allows — don't assume.** `--merge` fails on a
+squash-only repo, and using the wrong method can defeat release tooling that reads the
+squash commit. Check first:
 
 ```bash
-gh pr merge <number> --merge --delete-branch
+gh repo view --json mergeCommitAllowed,squashMergeAllowed,rebaseMergeAllowed
 ```
 
-Confirm:
+Choose the matching flag — `--squash`, `--merge`, or `--rebase`. If several are allowed,
+follow the repo's convention (release-please / changeset repos almost always squash); if
+still unsure, ask. Then merge, letting `gh` handle the branch:
 
 ```bash
-gh pr view <number> --json state,closedAt,mergedAt,mergedBy,mergeCommit,url
-git fetch --prune origin
-git status --short --branch
+gh pr merge <number> --squash --delete-branch   # swap --squash for the allowed method
 ```
+
+`--delete-branch` deletes **both** the local and remote branch and checks you out onto
+the base branch — so there is no separate `git branch -d` to run, and no default-branch
+guard to worry about. Just confirm, refresh, and prune:
+
+```bash
+gh pr view <number> --json state,mergedAt,mergedBy,mergeCommit,url   # confirm it merged
+git pull --ff-only           # you're on the default branch now; bring it up to date
+git fetch --prune            # drop the stale remote-tracking ref
+git status --short --branch   # confirm a clean tree on the default branch
+```
+
+Edge cases: if a local branch somehow survives (e.g. you were never checked out on it and
+`gh` couldn't remove it), delete it with `git branch -d <branch>`, or `git branch -D`
+if it looks unmerged after a squash — confirm the merge landed via `gh pr view` first.
+If the tree wasn't clean going in, you likely staged unrelated files back in step 1 —
+resolve that rather than carrying junk onto the default branch.
+
+## Release Notes (reference for step 8 — do this *before* merging)
+
+Optional and detection-gated. Step 8 sends you here before the merge in step 9, because
+the leverage is entirely pre-merge (a squash commit and the release bot read the PR
+title/body you set now, and after merge the branch is gone). Skip the whole thing if the
+repo publishes no release notes.
+
+You already hold the full context of what this PR did, so you're well placed to make its
+release note *useful* — "Add retry with backoff to the upload client, fixing dropped
+uploads on flaky networks" beats an auto-generated "Merged PR #123." But how you help
+depends entirely on the repo's release mechanism, and the common mistake is hand-writing
+notes that a bot then overwrites. **Detect the mechanism first**, then act:
+
+```bash
+ls .changeset/ .release-please-manifest.json release-please-config.json 2>/dev/null
+grep -rilE 'release-please|semantic-release|changesets' .github/workflows 2>/dev/null
+ls CHANGELOG.md HISTORY.md 2>/dev/null
+```
+
+- **Automated from commits/PRs** (release-please, semantic-release, changesets — this
+  applies to many repos): the notes are generated from your **conventional-commit
+  messages and PR title/body**, not from a file you edit. Here the leverage is entirely
+  *before* merge — make the PR title a clean conventional summary (`feat(upload): retry
+  with backoff on network errors`) and write a body that reads well, since a squash merge
+  and the release bot pull from exactly that. Editing the generated `CHANGELOG.md`
+  directly is wasted work; the next release run overwrites it.
+- **Changesets specifically**: add a changeset file (`.changeset/<name>.md`) describing
+  the change in user-facing terms, rather than editing the changelog.
+- **Manually curated changelog** (a Keep-a-Changelog `CHANGELOG.md` with an `Unreleased`
+  section and no bot): offer to add a short human-readable entry under `Unreleased` as a
+  small commit on the branch before merge.
+- **No release notes at all**: skip this — don't introduce a changelog the repo never
+  asked for.
+
+Release notes are outward-facing, so **confirm the wording with the user before writing
+or committing** it, and match the repo's existing tone and entry format. If unsure which
+mechanism a repo uses, ask rather than guess — a wrong guess either gets overwritten or
+adds noise a maintainer has to clean up.
 
 ## Common Mistakes
 
 - Obeying a finding without verifying it against the code (Robin's model may be weak).
 - Treating severity or `confidence: high` as proof a finding is real.
 - Inventing a fix to satisfy a NOISE comment instead of replying with the reason.
-- Looping past 5 passes / re-running Robin indefinitely.
+- Looping past 5 passes / re-running Robin indefinitely instead of asking the user at the ceiling.
+- Miscounting passes — forgetting the auto-triggered review counts, so the loop drifts to 6–7.
+- One long blind `sleep` instead of polling ~30s and escalating to GitHub Actions after ~3 min.
+- Treating a slow/flaky provider as a clean pass rather than checking the Actions run.
 - Replying in one summary comment instead of separate inline replies.
 - Using REST comments only and missing unresolved `reviewThreads`.
 - Posting `/robin` right after PR creation and starting a duplicate run.
 - Treating a failed Robin run (INFRA) as code feedback.
+- Merging silently without telling the user it's ready and getting a go-ahead.
 - Merging while outdated or unresolved threads remain.
+- Leaving the user on the dead merged branch instead of checking out the default branch and deleting the local branch.
+- Hand-editing a generated `CHANGELOG.md` that the release bot will overwrite.
 - Staging unrelated dirty files while fixing PR feedback.
 
 ## References

--- a/skills/robin/references/github-pr-api-reference.md
+++ b/skills/robin/references/github-pr-api-reference.md
@@ -125,8 +125,13 @@ Returns all required checks and their current state. Use as final confirmation b
 ## Merge
 
 ```bash
-gh pr merge <number> --merge --delete-branch
+# Pick the method the repo allows — --merge fails on a squash-only repo.
+gh repo view --json mergeCommitAllowed,squashMergeAllowed,rebaseMergeAllowed
+gh pr merge <number> --squash --delete-branch   # or --merge / --rebase per the repo
 ```
+
+`--delete-branch` removes both the local and remote branch and checks you out onto the
+base branch, so no manual `git branch -d` is needed.
 
 Confirm after merge:
 

--- a/skills/robin/references/lessons-learned.md
+++ b/skills/robin/references/lessons-learned.md
@@ -92,5 +92,8 @@ fixing and re-requesting, burning GitHub Actions minutes and free-model calls fo
 without converging.
 
 **Fix in the skill:** Cap the loop at 5 review passes. On the ceiling, fix remaining verified
-bugs, reply/resolve open threads, run the green-light gate, and merge. Most PRs converge in
-one or two passes; five is the hard stop.
+bugs, reply/resolve open threads, run the green-light gate, and then **stop and ask the user**
+whether to keep going or merge as-is — do not auto-merge or auto-loop past 5 on your own.
+(Note: pushing that last fix auto-triggers Robin again; that re-review is the current pass
+completing, not a licence to start a 6th round.) Most PRs converge in one or two passes; five
+is the hard stop.


### PR DESCRIPTION
## What

Hardens the `robin` companion skill's review → fix → re-review → merge loop and adds a best-effort version self-check. All changes are to the skill and its references (no runtime/action code).

## Why

Real gaps observed in agent runs: blind waits instead of polling, pass-count drift past 5, silent merges, `--merge` breaking on squash-only repos, redundant branch cleanup that errored, and no signal when an installed skill is stale.

## Loop hardening

- **Poll ~30s** with a **~3-min GitHub Actions escalation** and an 8–10 min INFRA cap (a normal Robin run lands in ~1 min; longer silence usually means a flaky provider/model).
- **Count rounds, not raw runs**, and note a fix `push` may itself auto-trigger Robin (`pull_request: synchronize`) — that re-review *is* the current pass, and must not be double-requested with `/robin`.
- **At the 5-pass ceiling, stop and ask the user** (keep going = explicit override, vs. merge as-is) instead of auto-looping.
- **Notify + confirm before merge** (the one irreversible step); standing pre-authorization skips the prompt.
- **Detect the repo's allowed merge method** instead of hardcoding `--merge`.
- **Let `gh pr merge --delete-branch` do branch cleanup** + base checkout; dropped the redundant manual `git branch -d` that errored.
- Fix the in-progress probe (`gh run view`, not `--log-failed`) and pin the undefined grace period to ~3 min.
- Optional, detection-gated, **pre-merge release-notes step**: feed release tooling (release-please/changesets) rather than hand-editing a generated changelog.
- Bring `references/lessons-learned.md` and the API reference into agreement.

## Version self-check

- Versioned frontmatter with a release-please marker (wired via `extra-files` so it stays current).
- **Step 0**: compare the loaded skill's version to the latest release (best-effort, non-blocking); offer/auto-update via the cross-agent skills CLI. Ships `scripts/update.sh`.

## Testing

No live-PR behavioral run is possible in isolation, so validated via two adversarial review passes (cold-start scenario simulation + static contradiction audit) and one verification pass — which caught and fixed 8 defects, including one contradiction introduced mid-edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)