### PR TITLE
fix(skill): prefer squash merges in auto-releasing repos to avoid duplicate changelog entries

### DIFF
--- a/skills/robin/SKILL.md
+++ b/skills/robin/SKILL.md
@@ -348,9 +348,15 @@ squash commit. Check first:
 gh repo view --json mergeCommitAllowed,squashMergeAllowed,rebaseMergeAllowed
 ```
 
-Choose the matching flag — `--squash`, `--merge`, or `--rebase`. If several are allowed,
-follow the repo's convention (release-please / changeset repos almost always squash); if
-still unsure, ask. Then merge, letting `gh` handle the branch:
+Choose the matching flag — `--squash`, `--merge`, or `--rebase`. **In a repo that
+auto-releases (release-please / semantic-release / changesets), prefer `--squash` even
+when merge commits are also allowed.** A merge commit embeds the (conventional) PR title
+in its own message, so the release tool counts it *and* the underlying commit — you get
+duplicate changelog entries. Squash collapses the PR to one commit whose subject is the
+PR title, which becomes exactly one clean release-note line. Only fall back to `--merge`
+when the individual commits are each meant to be their own changelog entry (rare, and
+usually a sign the PR should have been split). If still unsure, ask. Then merge, letting
+`gh` handle the branch:
 
 ```bash
 gh pr merge <number> --squash --delete-branch   # swap --squash for the allowed method

--- a/skills/robin/references/lessons-learned.md
+++ b/skills/robin/references/lessons-learned.md
@@ -97,3 +97,16 @@ whether to keep going or merge as-is — do not auto-merge or auto-loop past 5 o
 (Note: pushing that last fix auto-triggers Robin again; that re-review is the current pass
 completing, not a licence to start a 6th round.) Most PRs converge in one or two passes; five
 is the hard stop.
+
+## Merge commits duplicated a release-please changelog entry
+
+**What happened:** A PR was merged with `--merge` into a release-please repo. The resulting
+release notes listed the same feature twice — once for the original `feat` commit, once for
+the merge commit, because the merge commit's message carried the conventional PR title and
+release-please parsed both.
+
+**Fix in the skill:** In an auto-releasing repo (release-please / semantic-release /
+changesets), **prefer `--squash`** even when merge commits are allowed. Squash collapses the
+PR into one commit whose subject is the PR title, yielding exactly one clean changelog line.
+Reserve `--merge` for the rare case where each underlying commit is deliberately its own
+release-note entry.


### PR DESCRIPTION
## What
Guide the Robin skill to prefer `--squash` when merging in repos that auto-release (release-please / semantic-release / changesets), even if merge commits are also allowed.

## Why
We hit this on #52: a `--merge` into this release-please repo produced **duplicate changelog entries** in v2.1.0 — the merge commit carries the conventional PR title in its own message, so release-please counts it *and* the underlying commit. Squash collapses the PR to one commit whose subject is the PR title → exactly one clean release-note line.

## Changes
- `SKILL.md` merge step: prefer `--squash` in auto-releasing repos; reserve `--merge` for the rare case where each commit is its own intended entry.
- `references/lessons-learned.md`: record the incident.

Paired with a repo setting change (squash-only) so the merge button can't reintroduce the problem. This PR is the first squash-merge dogfooding the practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)