### PR TITLE
ci: squash-merge release PRs so auto-release works under squash-only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,7 +107,8 @@ jobs:
           set -euo pipefail
 
           number="${{ steps.release-pr.outputs.number }}"
-          gh pr merge "$number" --merge --delete-branch
+          # Repo is squash-only; --merge would be rejected by branch settings.
+          gh pr merge "$number" --squash --delete-branch
           merge_sha=$(gh pr view "$number" --json mergeCommit -q '.mergeCommit.oid')
 
           if [ -z "$merge_sha" ] || [ "$merge_sha" = "null" ]; then

--- a/src/release-workflow.test.ts
+++ b/src/release-workflow.test.ts
@@ -57,7 +57,7 @@ describe("release workflow", () => {
     expect(releaseWorkflow).toMatch(
       /uses:\s*googleapis\/release-please-action@v4[\s\S]*?with:[\s\S]*?skip-github-release:\s*true/,
     );
-    expect(releaseWorkflow).toContain("gh pr merge \"$number\" --merge --delete-branch");
+    expect(releaseWorkflow).toContain("gh pr merge \"$number\" --squash --delete-branch");
     expect(releaseWorkflow).toContain("gh release create \"$tag\"");
     expect(releaseWorkflow).toContain("git push origin -f \"v$major\" \"v$major.$minor\"");
     expect(releaseWorkflow).toContain('if [ "$major" -ne 1 ]; then');


### PR DESCRIPTION
## What
The auto-release job merges the release-please PR with `gh pr merge --merge`. We just set the repo to **squash-only**, so `--merge` is now rejected — the v2.1.1 release PR failed to auto-merge and had to be finished by hand.

Switch that step to `--squash` to match the repo's allowed method.

## Why
Keeps the automated release flow working under the squash-only policy (which we adopted to avoid duplicate release-please changelog entries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)