### PR TITLE
feat: configurable review event (request_changes vs comment)

### DIFF
--- a/.github/robin.yml.example
+++ b/.github/robin.yml.example
@@ -4,7 +4,7 @@
 max-diff-size: 25000
 max-comments: 10
 json-response-mode: true
-# request-changes: false  # advisor mode — never block the PR, even on high findings
+# request-changes: true   # default; set false for advisor mode (never block the PR, even on high findings)
 
 skip-paths:
   - "**/generated/**"

--- a/.github/robin.yml.example
+++ b/.github/robin.yml.example
@@ -4,6 +4,7 @@
 max-diff-size: 25000
 max-comments: 10
 json-response-mode: true
+# request-changes: false  # advisor mode — never block the PR, even on high findings
 
 skip-paths:
   - "**/generated/**"

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,10 @@ inputs:
     description: "If true, the action will fail when high severity issues are found."
     required: false
     default: "false"
+  request-changes:
+    description: "If true (default), a high severity finding submits a blocking REQUEST_CHANGES review. Set to false to always post as a non-blocking COMMENT (advisor mode). Leave empty to use the repo config default."
+    required: false
+    default: ""
   max-diff-size:
     description: "Maximum diff size in characters to send to the model. Large diffs are truncated."
     required: false

--- a/action.yml
+++ b/action.yml
@@ -25,7 +25,7 @@ inputs:
     required: false
     default: "false"
   request-changes:
-    description: "If true (default), a high severity finding submits a blocking REQUEST_CHANGES review. Set to false to always post as a non-blocking COMMENT (advisor mode). Leave empty to use the repo config default."
+    description: "Whether a high severity finding submits a blocking REQUEST_CHANGES review. true posts REQUEST_CHANGES; false always posts a non-blocking COMMENT (advisor mode). Leave empty to use the repo config, which defaults to true."
     required: false
     default: ""
   max-diff-size:

--- a/dist/index.js
+++ b/dist/index.js
@@ -315,7 +315,11 @@ class GitHubReviewer {
         this.octokit = octokit;
         this.maxComments = Number.isFinite(maxComments) ? Math.max(0, maxComments) : 25;
     }
-    async postReview(owner, repo, pullNumber, findings) {
+    /** COMMENT unless a High finding exists AND request-changes is enabled (gatekeeper mode). */
+    static resolveReviewEvent(hasHigh, requestChanges) {
+        return hasHigh && requestChanges ? "REQUEST_CHANGES" : "COMMENT";
+    }
+    async postReview(owner, repo, pullNumber, findings, requestChanges = true) {
         try {
             core.info("Posting review to PR #" + pullNumber + "...");
             // Fetch file patches to map line positions
@@ -330,7 +334,7 @@ class GitHubReviewer {
             // Build the review summary body (high-level)
             const body = this.buildReviewBody(findings, postedFindings);
             // Determine review event type
-            const event = findings.high.length > 0 ? "REQUEST_CHANGES" : "COMMENT";
+            const event = GitHubReviewer.resolveReviewEvent(findings.high.length > 0, requestChanges);
             let review;
             let postedInlineComments = comments.length;
             try {
@@ -1032,6 +1036,7 @@ async function run() {
         const reviewInstructionsFile = core.getInput("review-instructions-file") || "";
         const configFile = core.getInput("config-file") || repo_config_1.DEFAULT_CONFIG_FILE;
         const jsonResponseModeInput = core.getInput("use-json-response-mode") || "";
+        const requestChangesInput = core.getInput("request-changes") || "";
         core.info(`Model: ${model || "(not configured)"}`);
         core.info(`Running /${command} on PR #${prNumber} in ${owner}/${repo}`);
         statusCommand = command === "summary" ? "summary" : "review";
@@ -1059,6 +1064,7 @@ async function run() {
         const maxDiffSize = (0, repo_config_1.resolveMaxDiffSize)(maxDiffSizeInput, repoConfig);
         const maxComments = (0, repo_config_1.resolveMaxComments)(maxCommentsInput, repoConfig);
         const jsonResponseMode = (0, repo_config_1.resolveJsonResponseMode)(jsonResponseModeInput, repoConfig);
+        const requestChanges = (0, repo_config_1.resolveRequestChanges)(requestChangesInput, repoConfig);
         const diff = await gitUtils.getPullRequestDiff(owner, repo, prNumber);
         if (!diff || diff.trim().length === 0) {
             core.warning("No diff found for this PR.");
@@ -1123,7 +1129,7 @@ async function run() {
             }
             core.info(`Found ${findings.high.length} high, ${findings.medium.length} medium, ${findings.low.length} low, ${findings.suggestions.length} suggestions`);
             const reviewer = new github_reviewer_1.GitHubReviewer(octokit, maxComments);
-            await reviewer.postReview(owner, repo, prNumber, findings);
+            await reviewer.postReview(owner, repo, prNumber, findings, requestChanges);
             await updateStatusComment(octokit, owner, repo, statusCommentId, buildCompletedStatusBody("review", findings));
             if (findings.high.length > 0 && failOnHigh) {
                 core.setFailed(`Found ${findings.high.length} high severity issue(s). Failing check.`);
@@ -1553,6 +1559,7 @@ exports.parseRepoConfigYaml = parseRepoConfigYaml;
 exports.resolveMaxDiffSize = resolveMaxDiffSize;
 exports.resolveMaxComments = resolveMaxComments;
 exports.resolveJsonResponseMode = resolveJsonResponseMode;
+exports.resolveRequestChanges = resolveRequestChanges;
 exports.DEFAULT_CONFIG_FILE = ".github/robin.yml";
 exports.DEFAULT_ACTION_MAX_DIFF_SIZE = 50000;
 /** Single default shared by action.yml and the reusable review.yml workflow. */
@@ -1592,6 +1599,11 @@ function parseRepoConfigYaml(text) {
         const jsonModeMatch = trimmed.match(/^json-response-mode:\s*(true|false)\s*$/i);
         if (jsonModeMatch) {
             config.jsonResponseMode = jsonModeMatch[1].toLowerCase() === "true";
+            continue;
+        }
+        const requestChangesMatch = trimmed.match(/^request-changes:\s*(true|false)\s*$/i);
+        if (requestChangesMatch) {
+            config.requestChanges = requestChangesMatch[1].toLowerCase() === "true";
         }
     }
     return config;
@@ -1620,6 +1632,14 @@ function resolveJsonResponseMode(actionInput, repoConfig) {
     if (actionInput === "false")
         return false;
     return repoConfig?.jsonResponseMode ?? true;
+}
+/** Whether a High finding submits a blocking REQUEST_CHANGES review. Default true (gatekeeper). */
+function resolveRequestChanges(actionInput, repoConfig) {
+    if (actionInput === "true")
+        return true;
+    if (actionInput === "false")
+        return false;
+    return repoConfig?.requestChanges ?? true;
 }
 //# sourceMappingURL=repo-config.js.map
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -1604,6 +1604,7 @@ function parseRepoConfigYaml(text) {
         const requestChangesMatch = trimmed.match(/^request-changes:\s*(true|false)\s*$/i);
         if (requestChangesMatch) {
             config.requestChanges = requestChangesMatch[1].toLowerCase() === "true";
+            continue;
         }
     }
     return config;

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -10,6 +10,7 @@ Copy [`.github/robin.yml.example`](../.github/robin.yml.example) to `.github/rob
 max-diff-size: 25000
 max-comments: 10
 json-response-mode: true
+request-changes: true
 skip-paths:
   - "**/generated/**"
 ```
@@ -19,6 +20,7 @@ skip-paths:
 | `max-diff-size` | Used when the workflow still passes the action default (`50000`) |
 | `max-comments` | Used when the workflow passes action default `25` or reusable workflow default `10` |
 | `json-response-mode` | Used when `use-json-response-mode` is empty (action default defers to this file) |
+| `request-changes` | Used when `request-changes` input is empty. `true` (default) blocks on high findings; `false` posts advisor-only comments |
 | `skip-paths` | Extra paths removed from the diff before the LLM call |
 
 Lockfiles (npm, yarn, pnpm, Cargo, Gemfile, poetry), `dist/`, `node_modules/`, and minified assets are always skipped automatically. If every changed file is skipped, the action posts a status comment and skips the LLM call.
@@ -108,6 +110,7 @@ Available on the [direct action](../action.yml) and the [reusable workflow](../.
 | `llm-base-url` | — | OpenAI-compatible base URL (required) |
 | `model` | — | Model name (required) |
 | `fail-on-high` | `false` | Fail the check if high-severity issues are found |
+| `request-changes` | empty → `true` (defer to repo config) | `true` submits a blocking REQUEST_CHANGES review on high findings; `false` posts a non-blocking COMMENT (advisor mode) |
 | `max-diff-size` | `50000` | Max diff characters sent to the model |
 | `max-output-tokens` | empty | Cap response tokens (optional) |
 | `llm-timeout-ms` | `600000` | LLM timeout (10 minutes) |

--- a/src/github-reviewer.test.ts
+++ b/src/github-reviewer.test.ts
@@ -1,6 +1,13 @@
 import { GitHubReviewer } from "./github-reviewer";
 
 describe("GitHubReviewer", () => {
+  it("resolves review event from high findings and request-changes mode", () => {
+    expect(GitHubReviewer.resolveReviewEvent(true, true)).toBe("REQUEST_CHANGES");
+    expect(GitHubReviewer.resolveReviewEvent(true, false)).toBe("COMMENT");
+    expect(GitHubReviewer.resolveReviewEvent(false, true)).toBe("COMMENT");
+    expect(GitHubReviewer.resolveReviewEvent(false, false)).toBe("COMMENT");
+  });
+
   it("detects new-file line numbers present in the diff", () => {
     const reviewer = new GitHubReviewer({} as any);
     const isLineInNewDiff = (reviewer as any).isLineInNewDiff.bind(reviewer) as (

--- a/src/github-reviewer.ts
+++ b/src/github-reviewer.ts
@@ -11,11 +11,17 @@ export class GitHubReviewer {
     this.maxComments = Number.isFinite(maxComments) ? Math.max(0, maxComments) : 25;
   }
 
+  /** COMMENT unless a High finding exists AND request-changes is enabled (gatekeeper mode). */
+  static resolveReviewEvent(hasHigh: boolean, requestChanges: boolean): "REQUEST_CHANGES" | "COMMENT" {
+    return hasHigh && requestChanges ? "REQUEST_CHANGES" : "COMMENT";
+  }
+
   async postReview(
     owner: string,
     repo: string,
     pullNumber: number,
-    findings: StructuredReview
+    findings: StructuredReview,
+    requestChanges = true
   ): Promise<void> {
     try {
       core.info("Posting review to PR #" + pullNumber + "...");
@@ -35,7 +41,7 @@ export class GitHubReviewer {
       const body = this.buildReviewBody(findings, postedFindings);
       
       // Determine review event type
-      const event = findings.high.length > 0 ? "REQUEST_CHANGES" : "COMMENT";
+      const event = GitHubReviewer.resolveReviewEvent(findings.high.length > 0, requestChanges);
       
       let review;
       let postedInlineComments = comments.length;

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,6 +15,7 @@ import {
   resolveJsonResponseMode,
   resolveMaxComments,
   resolveMaxDiffSize,
+  resolveRequestChanges,
 } from "./repo-config";
 import { getReviewPrompt, getSummaryPrompt, getHelpMessage } from "./prompts/review-prompts";
 import { ReviewerCommand, hasRequiredPermission, parseSlashCommand } from "./commands";
@@ -130,6 +131,7 @@ async function run(): Promise<void> {
     const reviewInstructionsFile = core.getInput("review-instructions-file") || "";
     const configFile = core.getInput("config-file") || DEFAULT_CONFIG_FILE;
     const jsonResponseModeInput = core.getInput("use-json-response-mode") || "";
+    const requestChangesInput = core.getInput("request-changes") || "";
 
     core.info(`Model: ${model || "(not configured)"}`);
 
@@ -175,6 +177,7 @@ async function run(): Promise<void> {
     const maxDiffSize = resolveMaxDiffSize(maxDiffSizeInput, repoConfig);
     const maxComments = resolveMaxComments(maxCommentsInput, repoConfig);
     const jsonResponseMode = resolveJsonResponseMode(jsonResponseModeInput, repoConfig);
+    const requestChanges = resolveRequestChanges(requestChangesInput, repoConfig);
 
     const diff = await gitUtils.getPullRequestDiff(owner, repo, prNumber);
     
@@ -310,7 +313,7 @@ async function run(): Promise<void> {
       core.info(`Found ${findings.high.length} high, ${findings.medium.length} medium, ${findings.low.length} low, ${findings.suggestions.length} suggestions`);
 
       const reviewer = new GitHubReviewer(octokit as any, maxComments);
-      await reviewer.postReview(owner, repo, prNumber, findings);
+      await reviewer.postReview(owner, repo, prNumber, findings, requestChanges);
       await updateStatusComment(octokit, owner, repo, statusCommentId, buildCompletedStatusBody("review", findings));
 
       if (findings.high.length > 0 && failOnHigh) {

--- a/src/repo-config.test.ts
+++ b/src/repo-config.test.ts
@@ -5,6 +5,7 @@ import {
   resolveJsonResponseMode,
   resolveMaxComments,
   resolveMaxDiffSize,
+  resolveRequestChanges,
 } from "./repo-config";
 
 describe("parseRepoConfigYaml", () => {
@@ -59,5 +60,14 @@ describe("resolveJsonResponseMode", () => {
     expect(resolveJsonResponseMode("true", { jsonResponseMode: false })).toBe(true);
     expect(resolveJsonResponseMode("", { jsonResponseMode: false })).toBe(false);
     expect(resolveJsonResponseMode("", undefined)).toBe(true);
+  });
+});
+
+describe("resolveRequestChanges", () => {
+  it("prefers explicit action input, then repo config, then default true", () => {
+    expect(resolveRequestChanges("false", { requestChanges: true })).toBe(false);
+    expect(resolveRequestChanges("true", { requestChanges: false })).toBe(true);
+    expect(resolveRequestChanges("", { requestChanges: false })).toBe(false);
+    expect(resolveRequestChanges("", undefined)).toBe(true);
   });
 });

--- a/src/repo-config.ts
+++ b/src/repo-config.ts
@@ -8,6 +8,7 @@ export interface RepoConfig {
   maxComments?: number;
   skipPaths?: string[];
   jsonResponseMode?: boolean;
+  requestChanges?: boolean;
 }
 
 export function parseRepoConfigYaml(text: string): RepoConfig {
@@ -50,6 +51,12 @@ export function parseRepoConfigYaml(text: string): RepoConfig {
     const jsonModeMatch = trimmed.match(/^json-response-mode:\s*(true|false)\s*$/i);
     if (jsonModeMatch) {
       config.jsonResponseMode = jsonModeMatch[1].toLowerCase() === "true";
+      continue;
+    }
+
+    const requestChangesMatch = trimmed.match(/^request-changes:\s*(true|false)\s*$/i);
+    if (requestChangesMatch) {
+      config.requestChanges = requestChangesMatch[1].toLowerCase() === "true";
     }
   }
 
@@ -82,4 +89,11 @@ export function resolveJsonResponseMode(actionInput: string, repoConfig?: RepoCo
   if (actionInput === "true") return true;
   if (actionInput === "false") return false;
   return repoConfig?.jsonResponseMode ?? true;
+}
+
+/** Whether a High finding submits a blocking REQUEST_CHANGES review. Default true (gatekeeper). */
+export function resolveRequestChanges(actionInput: string, repoConfig?: RepoConfig): boolean {
+  if (actionInput === "true") return true;
+  if (actionInput === "false") return false;
+  return repoConfig?.requestChanges ?? true;
 }

--- a/src/repo-config.ts
+++ b/src/repo-config.ts
@@ -57,6 +57,7 @@ export function parseRepoConfigYaml(text: string): RepoConfig {
     const requestChangesMatch = trimmed.match(/^request-changes:\s*(true|false)\s*$/i);
     if (requestChangesMatch) {
       config.requestChanges = requestChangesMatch[1].toLowerCase() === "true";
+      continue;
     }
   }
 


### PR DESCRIPTION
## What

Adds a `request-changes` option that controls whether a **High** severity finding submits a blocking `REQUEST_CHANGES` review or a non-blocking `COMMENT`.

- `request-changes: true` (default) — current behavior. High findings block the PR (gatekeeper).
- `request-changes: false` — Robin always posts as `COMMENT` (advisor mode). It still surfaces every finding, but a human stays the final merge decision.

Settable as an action input **or** in `.github/robin.yml`, matching the existing `json-response-mode` / `max-comments` resolution (explicit input > repo config > default).

## Why

Closes #59. Larger teams use Robin as an assistant, not the final reviewer. Today a single false-positive High leaves an active Request Changes that, under branch protection, blocks merge until a human manually dismisses it. This makes the block opt-out without changing anyone's current setup.

## Changes

- `request-changes` action input (`action.yml`) + `request-changes` key in repo config
- `resolveRequestChanges()` resolver + `GitHubReviewer.resolveReviewEvent()` (event logic extracted, unit-tested)
- Threaded through `main.ts` → `postReview()`
- Docs: `docs/ADVANCED.md` tables + `.github/robin.yml.example`
- Rebuilt `dist/`

## Tests

`62 passed` — added coverage for `resolveRequestChanges` and the review-event decision (4 combinations).

Fully backwards compatible: default is `true`, so existing gatekeeper behavior is unchanged.