### PR TITLE
fix: superseded-run cancel notice and dismiss stale Robin reviews

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -325,6 +325,7 @@ class GitHubReviewer {
     static isStaleRobinReview(review, newReviewId) {
         return (review.id !== newReviewId &&
             review.state === "CHANGES_REQUESTED" &&
+            review.user?.type === "Bot" &&
             (review.body || "").includes(exports.ROBIN_SIGNATURE));
     }
     /**

--- a/dist/index.js
+++ b/dist/index.js
@@ -1087,7 +1087,12 @@ async function run() {
         statusCommentId = await postStatusComment(octokit, owner, repo, prNumber, command, statusModel);
         onJobCancelled = async () => {
             if (octokit && statusCommentId) {
-                const superseded = await isSupersededByNewerRun(octokit, statusOwner, statusRepo);
+                // The SIGTERM grace period is short — never let the superseded check
+                // delay the status update past it.
+                const superseded = await Promise.race([
+                    isSupersededByNewerRun(octokit, statusOwner, statusRepo),
+                    new Promise((resolve) => setTimeout(() => resolve(false), 3000).unref()),
+                ]);
                 await updateStatusComment(octokit, statusOwner, statusRepo, statusCommentId, superseded
                     ? buildSupersededStatusBody(statusCommand)
                     : buildCancelledStatusBody(statusCommand));
@@ -1157,7 +1162,7 @@ async function run() {
                 owner,
                 repo,
                 issue_number: prNumber,
-                body: ["## :bow_and_arrow: Robin · Summary", "", reviewText].join("\n"),
+                body: ["## " + github_reviewer_1.ROBIN_SIGNATURE + " · Summary", "", reviewText].join("\n"),
             });
             await updateStatusComment(octokit, owner, repo, statusCommentId, buildCompletedStatusBody("summary"));
         }
@@ -1217,7 +1222,7 @@ async function postStatusComment(octokit, owner, repo, issueNumber, command, mod
             repo,
             issue_number: issueNumber,
             body: [
-                "## :bow_and_arrow: Robin",
+                "## " + github_reviewer_1.ROBIN_SIGNATURE,
                 "",
                 ":eyes: On it — taking a look at this pull request.",
                 "",
@@ -1250,7 +1255,7 @@ async function updateStatusComment(octokit, owner, repo, commentId, body) {
 function buildCompletedStatusBody(command, findings) {
     if (command === "summary") {
         return [
-            "## :bow_and_arrow: Robin",
+            "## " + github_reviewer_1.ROBIN_SIGNATURE,
             "",
             ":white_check_mark: Summary's ready above.",
             "",
@@ -1264,7 +1269,7 @@ function buildCompletedStatusBody(command, findings) {
         ? "Nothing worth flagging — looks clean to me."
         : `I flagged ${totalFindings} thing${totalFindings === 1 ? "" : "s"} worth a look.`;
     return [
-        "## :bow_and_arrow: Robin",
+        "## " + github_reviewer_1.ROBIN_SIGNATURE,
         "",
         `:white_check_mark: Review done. ${result}`,
         "",
@@ -1275,7 +1280,7 @@ function buildSkippedFilterStatusBody(removedFiles) {
     const preview = removedFiles.slice(0, 8).join(", ");
     const suffix = removedFiles.length > 8 ? `, and ${removedFiles.length - 8} more` : "";
     return [
-        "## :bow_and_arrow: Robin",
+        "## " + github_reviewer_1.ROBIN_SIGNATURE,
         "",
         ":white_check_mark: Nothing to review here — only ignored paths changed.",
         "",
@@ -1286,7 +1291,7 @@ function buildSkippedFilterStatusBody(removedFiles) {
 }
 function buildFailedStatusBody(errorMessage, command) {
     return [
-        "## :bow_and_arrow: Robin",
+        "## " + github_reviewer_1.ROBIN_SIGNATURE,
         "",
         `:warning: I couldn't finish the ${command === "summary" ? "summary" : "review"} this time.`,
         "",
@@ -1297,7 +1302,7 @@ function buildFailedStatusBody(errorMessage, command) {
 }
 function buildProgressStatusBody(detail, command, model) {
     return [
-        "## :bow_and_arrow: Robin",
+        "## " + github_reviewer_1.ROBIN_SIGNATURE,
         "",
         ":hourglass_flowing_sand: Still working on this pull request.",
         "",
@@ -1344,7 +1349,7 @@ async function isSupersededByNewerRun(octokit, owner, repo) {
 }
 function buildSupersededStatusBody(command) {
     return [
-        "## :bow_and_arrow: Robin",
+        "## " + github_reviewer_1.ROBIN_SIGNATURE,
         "",
         `:arrows_counterclockwise: This ${command === "summary" ? "summary" : "review"} run was replaced by a newer Robin run on this pull request.`,
         "",
@@ -1353,7 +1358,7 @@ function buildSupersededStatusBody(command) {
 }
 function buildCancelledStatusBody(command) {
     return [
-        "## :bow_and_arrow: Robin",
+        "## " + github_reviewer_1.ROBIN_SIGNATURE,
         "",
         `:warning: The ${command === "summary" ? "summary" : "review"} was interrupted before it finished.`,
         "",

--- a/dist/index.js
+++ b/dist/index.js
@@ -319,6 +319,46 @@ class GitHubReviewer {
     static resolveReviewEvent(hasHigh, requestChanges) {
         return hasHigh && requestChanges ? "REQUEST_CHANGES" : "COMMENT";
     }
+    /** A prior Robin CHANGES_REQUESTED review that a newly posted review supersedes. */
+    static isStaleRobinReview(review, newReviewId) {
+        return (review.id !== newReviewId &&
+            review.state === "CHANGES_REQUESTED" &&
+            (review.body || "").includes(":bow_and_arrow: Robin"));
+    }
+    /**
+     * Dismiss earlier Robin CHANGES_REQUESTED reviews so a stale blocking review
+     * from a previous (possibly cancelled) run doesn't keep gating the PR.
+     */
+    async dismissStaleRobinReviews(owner, repo, pullNumber, newReviewId) {
+        try {
+            const reviews = await this.octokit.paginate(this.octokit.rest.pulls.listReviews, {
+                owner,
+                repo,
+                pull_number: pullNumber,
+                per_page: 100,
+            });
+            for (const review of reviews) {
+                if (!GitHubReviewer.isStaleRobinReview(review, newReviewId))
+                    continue;
+                try {
+                    await this.octokit.rest.pulls.dismissReview({
+                        owner,
+                        repo,
+                        pull_number: pullNumber,
+                        review_id: review.id,
+                        message: "Superseded by a newer Robin review.",
+                    });
+                    core.info("Dismissed stale Robin review #" + review.id);
+                }
+                catch (error) {
+                    core.warning("Could not dismiss stale Robin review #" + review.id + ": " + error);
+                }
+            }
+        }
+        catch (error) {
+            core.warning("Could not check for stale Robin reviews: " + error);
+        }
+    }
     async postReview(owner, repo, pullNumber, findings, requestChanges = true) {
         try {
             core.info("Posting review to PR #" + pullNumber + "...");
@@ -365,6 +405,7 @@ class GitHubReviewer {
                 postedInlineComments = 0;
             }
             core.info("Posted review #" + review.id + " with " + postedInlineComments + " individual line comments");
+            await this.dismissStaleRobinReviews(owner, repo, pullNumber, review.id);
         }
         catch (error) {
             core.error("Failed to post review: " + error);
@@ -1044,7 +1085,10 @@ async function run() {
         statusCommentId = await postStatusComment(octokit, owner, repo, prNumber, command, statusModel);
         onJobCancelled = async () => {
             if (octokit && statusCommentId) {
-                await updateStatusComment(octokit, statusOwner, statusRepo, statusCommentId, buildCancelledStatusBody(statusCommand));
+                const superseded = await isSupersededByNewerRun(octokit, statusOwner, statusRepo);
+                await updateStatusComment(octokit, statusOwner, statusRepo, statusCommentId, superseded
+                    ? buildSupersededStatusBody(statusCommand)
+                    : buildCancelledStatusBody(statusCommand));
             }
         };
         registerJobCancelHandler(async () => {
@@ -1259,6 +1303,50 @@ function buildProgressStatusBody(detail, command, model) {
         "",
         `Mode: ${command === "summary" ? "summary" : "code review"}`,
         `Model: ${model}`,
+    ].join("\n");
+}
+/**
+ * True when a newer run of this same workflow is queued or in progress —
+ * i.e. this run was cancelled by concurrency `cancel-in-progress`, not by a
+ * human or a timeout. Best-effort: any API failure returns false.
+ * ponytail: may match a newer run on a different PR; acceptable — it only
+ * softens the wording of a cancel notice, upgrade to per-PR matching if needed.
+ */
+async function isSupersededByNewerRun(octokit, owner, repo) {
+    try {
+        const runId = Number(process.env.GITHUB_RUN_ID);
+        if (!runId)
+            return false;
+        const { data: currentRun } = await octokit.rest.actions.getWorkflowRun({
+            owner,
+            repo,
+            run_id: runId,
+        });
+        for (const status of ["queued", "in_progress"]) {
+            const { data } = await octokit.rest.actions.listWorkflowRuns({
+                owner,
+                repo,
+                workflow_id: currentRun.workflow_id,
+                status,
+                per_page: 30,
+            });
+            if (data.workflow_runs.some((run) => run.id !== runId && run.run_number > currentRun.run_number)) {
+                return true;
+            }
+        }
+    }
+    catch (error) {
+        core.warning(`Could not check for a superseding run: ${error}`);
+    }
+    return false;
+}
+function buildSupersededStatusBody(command) {
+    return [
+        "## :bow_and_arrow: Robin",
+        "",
+        `:arrows_counterclockwise: This ${command === "summary" ? "summary" : "review"} run was replaced by a newer Robin run on this pull request.`,
+        "",
+        "No action needed — the newer run's comment below has the result.",
     ].join("\n");
 }
 function buildCancelledStatusBody(command) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -1088,7 +1088,8 @@ async function run() {
         onJobCancelled = async () => {
             if (octokit && statusCommentId) {
                 // The SIGTERM grace period is short — never let the superseded check
-                // delay the status update past it.
+                // delay the status update past it. On timeout the check is abandoned
+                // fire-and-forget; its own try/catch swallows any late rejection.
                 const superseded = await Promise.race([
                     isSupersededByNewerRun(octokit, statusOwner, statusRepo),
                     new Promise((resolve) => setTimeout(() => resolve(false), 3000).unref()),
@@ -1329,14 +1330,14 @@ async function isSupersededByNewerRun(octokit, owner, repo) {
             repo,
             run_id: runId,
         });
-        for (const status of ["queued", "in_progress"]) {
-            const { data } = await octokit.rest.actions.listWorkflowRuns({
-                owner,
-                repo,
-                workflow_id: currentRun.workflow_id,
-                status,
-                per_page: 30,
-            });
+        const results = await Promise.all(["queued", "in_progress"].map((status) => octokit.rest.actions.listWorkflowRuns({
+            owner,
+            repo,
+            workflow_id: currentRun.workflow_id,
+            status,
+            per_page: 30,
+        })));
+        for (const { data } of results) {
             if (data.workflow_runs.some((run) => run.id !== runId && run.run_number > currentRun.run_number)) {
                 return true;
             }

--- a/dist/index.js
+++ b/dist/index.js
@@ -1316,8 +1316,8 @@ function buildProgressStatusBody(detail, command, model) {
  * True when a newer run of this same workflow is queued or in progress —
  * i.e. this run was cancelled by concurrency `cancel-in-progress`, not by a
  * human or a timeout. Best-effort: any API failure returns false.
- * ponytail: may match a newer run on a different PR; acceptable — it only
- * softens the wording of a cancel notice, upgrade to per-PR matching if needed.
+ * Note: may match a newer run on a different PR; acceptable — it only
+ * softens the wording of a cancel notice. Upgrade to per-PR matching if needed.
  */
 async function isSupersededByNewerRun(octokit, owner, repo) {
     try {
@@ -1351,9 +1351,9 @@ function buildSupersededStatusBody(command) {
     return [
         "## " + github_reviewer_1.ROBIN_SIGNATURE,
         "",
-        `:arrows_counterclockwise: This ${command === "summary" ? "summary" : "review"} run was replaced by a newer Robin run on this pull request.`,
+        `:arrows_counterclockwise: This ${command === "summary" ? "summary" : "review"} run was replaced by a newer Robin run.`,
         "",
-        "No action needed — the newer run's comment below has the result.",
+        "No action needed — the newer run posts its own result when it finishes.",
     ].join("\n");
 }
 function buildCancelledStatusBody(command) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -306,8 +306,10 @@ var __importStar = (this && this.__importStar) || (function () {
     };
 })();
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.GitHubReviewer = void 0;
+exports.GitHubReviewer = exports.ROBIN_SIGNATURE = void 0;
 const core = __importStar(__nccwpck_require__(7484));
+/** Marker present in every Robin review body; used to recognize Robin's own reviews. */
+exports.ROBIN_SIGNATURE = ":bow_and_arrow: Robin";
 class GitHubReviewer {
     octokit;
     maxComments;
@@ -323,7 +325,7 @@ class GitHubReviewer {
     static isStaleRobinReview(review, newReviewId) {
         return (review.id !== newReviewId &&
             review.state === "CHANGES_REQUESTED" &&
-            (review.body || "").includes(":bow_and_arrow: Robin"));
+            (review.body || "").includes(exports.ROBIN_SIGNATURE));
     }
     /**
      * Dismiss earlier Robin CHANGES_REQUESTED reviews so a stale blocking review
@@ -493,7 +495,7 @@ class GitHubReviewer {
      */
     buildReviewBody(findings, postedFindings) {
         const parts = [];
-        parts.push("## :bow_and_arrow: Robin");
+        parts.push("## " + exports.ROBIN_SIGNATURE);
         parts.push("");
         parts.push("> **Heads up:** this is a point-in-time review. Push fixes freely, then comment `/robin` whenever you want another pass.");
         parts.push("");

--- a/src/github-reviewer.test.ts
+++ b/src/github-reviewer.test.ts
@@ -28,6 +28,29 @@ describe("GitHubReviewer", () => {
     expect(GitHubReviewer.isStaleRobinReview({ id: 1, state: "CHANGES_REQUESTED", body: null }, 2)).toBe(false);
   });
 
+  it("dismisses only stale Robin CHANGES_REQUESTED reviews after posting", async () => {
+    const robinBody = "## :bow_and_arrow: Robin\n\nfindings…";
+    const reviews = [
+      { id: 10, state: "CHANGES_REQUESTED", body: robinBody }, // stale — dismiss
+      { id: 11, state: "COMMENTED", body: robinBody }, // non-blocking — keep
+      { id: 12, state: "CHANGES_REQUESTED", body: "human review" }, // human — keep
+      { id: 20, state: "CHANGES_REQUESTED", body: robinBody }, // the new review itself
+    ];
+    const dismissReview = jest.fn().mockResolvedValue({});
+    const octokit = {
+      paginate: jest.fn().mockResolvedValue(reviews),
+      rest: { pulls: { listReviews: {}, dismissReview } },
+    };
+
+    const reviewer = new GitHubReviewer(octokit as any);
+    await (reviewer as any).dismissStaleRobinReviews("o", "r", 1, 20);
+
+    expect(dismissReview).toHaveBeenCalledTimes(1);
+    expect(dismissReview).toHaveBeenCalledWith(
+      expect.objectContaining({ review_id: 10, pull_number: 1 })
+    );
+  });
+
   it("detects new-file line numbers present in the diff", () => {
     const reviewer = new GitHubReviewer({} as any);
     const isLineInNewDiff = (reviewer as any).isLineInNewDiff.bind(reviewer) as (

--- a/src/github-reviewer.test.ts
+++ b/src/github-reviewer.test.ts
@@ -8,6 +8,26 @@ describe("GitHubReviewer", () => {
     expect(GitHubReviewer.resolveReviewEvent(false, false)).toBe("COMMENT");
   });
 
+  it("identifies stale Robin CHANGES_REQUESTED reviews to dismiss", () => {
+    const robinBody = "## :bow_and_arrow: Robin\n\nfindings…";
+    expect(
+      GitHubReviewer.isStaleRobinReview({ id: 1, state: "CHANGES_REQUESTED", body: robinBody }, 2)
+    ).toBe(true);
+    // the review just posted
+    expect(
+      GitHubReviewer.isStaleRobinReview({ id: 2, state: "CHANGES_REQUESTED", body: robinBody }, 2)
+    ).toBe(false);
+    // non-blocking Robin review
+    expect(
+      GitHubReviewer.isStaleRobinReview({ id: 1, state: "COMMENTED", body: robinBody }, 2)
+    ).toBe(false);
+    // human review must never be dismissed
+    expect(
+      GitHubReviewer.isStaleRobinReview({ id: 1, state: "CHANGES_REQUESTED", body: "LGTM-ish" }, 2)
+    ).toBe(false);
+    expect(GitHubReviewer.isStaleRobinReview({ id: 1, state: "CHANGES_REQUESTED", body: null }, 2)).toBe(false);
+  });
+
   it("detects new-file line numbers present in the diff", () => {
     const reviewer = new GitHubReviewer({} as any);
     const isLineInNewDiff = (reviewer as any).isLineInNewDiff.bind(reviewer) as (

--- a/src/github-reviewer.test.ts
+++ b/src/github-reviewer.test.ts
@@ -10,31 +10,41 @@ describe("GitHubReviewer", () => {
 
   it("identifies stale Robin CHANGES_REQUESTED reviews to dismiss", () => {
     const robinBody = "## :bow_and_arrow: Robin\n\nfindings…";
+    const bot = { type: "Bot" };
     expect(
-      GitHubReviewer.isStaleRobinReview({ id: 1, state: "CHANGES_REQUESTED", body: robinBody }, 2)
+      GitHubReviewer.isStaleRobinReview({ id: 1, state: "CHANGES_REQUESTED", body: robinBody, user: bot }, 2)
     ).toBe(true);
     // the review just posted
     expect(
-      GitHubReviewer.isStaleRobinReview({ id: 2, state: "CHANGES_REQUESTED", body: robinBody }, 2)
+      GitHubReviewer.isStaleRobinReview({ id: 2, state: "CHANGES_REQUESTED", body: robinBody, user: bot }, 2)
     ).toBe(false);
     // non-blocking Robin review
     expect(
-      GitHubReviewer.isStaleRobinReview({ id: 1, state: "COMMENTED", body: robinBody }, 2)
+      GitHubReviewer.isStaleRobinReview({ id: 1, state: "COMMENTED", body: robinBody, user: bot }, 2)
     ).toBe(false);
-    // human review must never be dismissed
+    // human review must never be dismissed — even one quoting Robin's signature
     expect(
-      GitHubReviewer.isStaleRobinReview({ id: 1, state: "CHANGES_REQUESTED", body: "LGTM-ish" }, 2)
+      GitHubReviewer.isStaleRobinReview(
+        { id: 1, state: "CHANGES_REQUESTED", body: robinBody, user: { type: "User" } },
+        2
+      )
     ).toBe(false);
-    expect(GitHubReviewer.isStaleRobinReview({ id: 1, state: "CHANGES_REQUESTED", body: null }, 2)).toBe(false);
+    expect(
+      GitHubReviewer.isStaleRobinReview({ id: 1, state: "CHANGES_REQUESTED", body: "LGTM-ish", user: bot }, 2)
+    ).toBe(false);
+    expect(
+      GitHubReviewer.isStaleRobinReview({ id: 1, state: "CHANGES_REQUESTED", body: null, user: bot }, 2)
+    ).toBe(false);
   });
 
   it("dismisses only stale Robin CHANGES_REQUESTED reviews after posting", async () => {
     const robinBody = "## :bow_and_arrow: Robin\n\nfindings…";
+    const bot = { type: "Bot" };
     const reviews = [
-      { id: 10, state: "CHANGES_REQUESTED", body: robinBody }, // stale — dismiss
-      { id: 11, state: "COMMENTED", body: robinBody }, // non-blocking — keep
-      { id: 12, state: "CHANGES_REQUESTED", body: "human review" }, // human — keep
-      { id: 20, state: "CHANGES_REQUESTED", body: robinBody }, // the new review itself
+      { id: 10, state: "CHANGES_REQUESTED", body: robinBody, user: bot }, // stale — dismiss
+      { id: 11, state: "COMMENTED", body: robinBody, user: bot }, // non-blocking — keep
+      { id: 12, state: "CHANGES_REQUESTED", body: "human review", user: { type: "User" } }, // human — keep
+      { id: 20, state: "CHANGES_REQUESTED", body: robinBody, user: bot }, // the new review itself
     ];
     const dismissReview = jest.fn().mockResolvedValue({});
     const octokit = {

--- a/src/github-reviewer.ts
+++ b/src/github-reviewer.ts
@@ -16,6 +16,56 @@ export class GitHubReviewer {
     return hasHigh && requestChanges ? "REQUEST_CHANGES" : "COMMENT";
   }
 
+  /** A prior Robin CHANGES_REQUESTED review that a newly posted review supersedes. */
+  static isStaleRobinReview(
+    review: { id: number; state?: string; body?: string | null },
+    newReviewId: number
+  ): boolean {
+    return (
+      review.id !== newReviewId &&
+      review.state === "CHANGES_REQUESTED" &&
+      (review.body || "").includes(":bow_and_arrow: Robin")
+    );
+  }
+
+  /**
+   * Dismiss earlier Robin CHANGES_REQUESTED reviews so a stale blocking review
+   * from a previous (possibly cancelled) run doesn't keep gating the PR.
+   */
+  private async dismissStaleRobinReviews(
+    owner: string,
+    repo: string,
+    pullNumber: number,
+    newReviewId: number
+  ): Promise<void> {
+    try {
+      const reviews = await this.octokit.paginate(this.octokit.rest.pulls.listReviews, {
+        owner,
+        repo,
+        pull_number: pullNumber,
+        per_page: 100,
+      });
+
+      for (const review of reviews) {
+        if (!GitHubReviewer.isStaleRobinReview(review, newReviewId)) continue;
+        try {
+          await this.octokit.rest.pulls.dismissReview({
+            owner,
+            repo,
+            pull_number: pullNumber,
+            review_id: review.id,
+            message: "Superseded by a newer Robin review.",
+          });
+          core.info("Dismissed stale Robin review #" + review.id);
+        } catch (error) {
+          core.warning("Could not dismiss stale Robin review #" + review.id + ": " + error);
+        }
+      }
+    } catch (error) {
+      core.warning("Could not check for stale Robin reviews: " + error);
+    }
+  }
+
   async postReview(
     owner: string,
     repo: string,
@@ -78,6 +128,8 @@ export class GitHubReviewer {
       core.info(
         "Posted review #" + review.id + " with " + postedInlineComments + " individual line comments"
       );
+
+      await this.dismissStaleRobinReviews(owner, repo, pullNumber, review.id);
 
     } catch (error) {
       core.error("Failed to post review: " + error);

--- a/src/github-reviewer.ts
+++ b/src/github-reviewer.ts
@@ -2,6 +2,9 @@ import { Octokit } from "@octokit/rest";
 import * as core from "@actions/core";
 import { StructuredReview, ReviewFinding } from "./review-parser";
 
+/** Marker present in every Robin review body; used to recognize Robin's own reviews. */
+export const ROBIN_SIGNATURE = ":bow_and_arrow: Robin";
+
 export class GitHubReviewer {
   private octokit: Octokit;
   private maxComments: number;
@@ -24,7 +27,7 @@ export class GitHubReviewer {
     return (
       review.id !== newReviewId &&
       review.state === "CHANGES_REQUESTED" &&
-      (review.body || "").includes(":bow_and_arrow: Robin")
+      (review.body || "").includes(ROBIN_SIGNATURE)
     );
   }
 
@@ -250,7 +253,7 @@ export class GitHubReviewer {
   private buildReviewBody(findings: StructuredReview, postedFindings: Set<ReviewFinding>): string {
     const parts: string[] = [];
 
-    parts.push("## :bow_and_arrow: Robin");
+    parts.push("## " + ROBIN_SIGNATURE);
     parts.push("");
     parts.push(
       "> **Heads up:** this is a point-in-time review. Push fixes freely, then comment `/robin` whenever you want another pass."

--- a/src/github-reviewer.ts
+++ b/src/github-reviewer.ts
@@ -21,12 +21,13 @@ export class GitHubReviewer {
 
   /** A prior Robin CHANGES_REQUESTED review that a newly posted review supersedes. */
   static isStaleRobinReview(
-    review: { id: number; state?: string; body?: string | null },
+    review: { id: number; state?: string; body?: string | null; user?: { type?: string } | null },
     newReviewId: number
   ): boolean {
     return (
       review.id !== newReviewId &&
       review.state === "CHANGES_REQUESTED" &&
+      review.user?.type === "Bot" &&
       (review.body || "").includes(ROBIN_SIGNATURE)
     );
   }

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,7 +4,7 @@ import { LLMClient } from "./llm-client";
 import { GitUtils } from "./git-utils";
 import { ReviewParser, StructuredReview } from "./review-parser";
 import { shouldRetryStructuredReview } from "./review-retry";
-import { GitHubReviewer } from "./github-reviewer";
+import { GitHubReviewer, ROBIN_SIGNATURE } from "./github-reviewer";
 import { DEFAULT_LLM_TIMEOUT_MS, parseLLMTimeout } from "./config";
 import { filterDiff, splitDiffIntoFiles } from "./diff-filter";
 import { annotateDiffWithLineNumbers } from "./diff-annotate";
@@ -141,7 +141,12 @@ async function run(): Promise<void> {
     statusCommentId = await postStatusComment(octokit, owner, repo, prNumber, command, statusModel);
     onJobCancelled = async () => {
       if (octokit && statusCommentId) {
-        const superseded = await isSupersededByNewerRun(octokit, statusOwner, statusRepo);
+        // The SIGTERM grace period is short — never let the superseded check
+        // delay the status update past it.
+        const superseded = await Promise.race([
+          isSupersededByNewerRun(octokit, statusOwner, statusRepo),
+          new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 3000).unref()),
+        ]);
         await updateStatusComment(
           octokit,
           statusOwner,
@@ -279,7 +284,7 @@ async function run(): Promise<void> {
         owner,
         repo,
         issue_number: prNumber,
-        body: ["## :bow_and_arrow: Robin · Summary", "", reviewText].join("\n"),
+        body: ["## " + ROBIN_SIGNATURE + " · Summary", "", reviewText].join("\n"),
       });
       await updateStatusComment(octokit, owner, repo, statusCommentId, buildCompletedStatusBody("summary"));
     } else {
@@ -372,7 +377,7 @@ async function postStatusComment(
       repo,
       issue_number: issueNumber,
       body: [
-        "## :bow_and_arrow: Robin",
+        "## " + ROBIN_SIGNATURE,
         "",
         ":eyes: On it — taking a look at this pull request.",
         "",
@@ -411,7 +416,7 @@ async function updateStatusComment(
 function buildCompletedStatusBody(command: "review" | "summary", findings?: StructuredReview): string {
   if (command === "summary") {
     return [
-      "## :bow_and_arrow: Robin",
+      "## " + ROBIN_SIGNATURE,
       "",
       ":white_check_mark: Summary's ready above.",
       "",
@@ -427,7 +432,7 @@ function buildCompletedStatusBody(command: "review" | "summary", findings?: Stru
     : `I flagged ${totalFindings} thing${totalFindings === 1 ? "" : "s"} worth a look.`;
 
   return [
-    "## :bow_and_arrow: Robin",
+    "## " + ROBIN_SIGNATURE,
     "",
     `:white_check_mark: Review done. ${result}`,
     "",
@@ -440,7 +445,7 @@ function buildSkippedFilterStatusBody(removedFiles: string[]): string {
   const suffix = removedFiles.length > 8 ? `, and ${removedFiles.length - 8} more` : "";
 
   return [
-    "## :bow_and_arrow: Robin",
+    "## " + ROBIN_SIGNATURE,
     "",
     ":white_check_mark: Nothing to review here — only ignored paths changed.",
     "",
@@ -452,7 +457,7 @@ function buildSkippedFilterStatusBody(removedFiles: string[]): string {
 
 function buildFailedStatusBody(errorMessage: string, command: "review" | "summary"): string {
   return [
-    "## :bow_and_arrow: Robin",
+    "## " + ROBIN_SIGNATURE,
     "",
     `:warning: I couldn't finish the ${command === "summary" ? "summary" : "review"} this time.`,
     "",
@@ -468,7 +473,7 @@ function buildProgressStatusBody(
   model: string
 ): string {
   return [
-    "## :bow_and_arrow: Robin",
+    "## " + ROBIN_SIGNATURE,
     "",
     ":hourglass_flowing_sand: Still working on this pull request.",
     "",
@@ -517,7 +522,7 @@ async function isSupersededByNewerRun(octokit: any, owner: string, repo: string)
 
 function buildSupersededStatusBody(command: "review" | "summary"): string {
   return [
-    "## :bow_and_arrow: Robin",
+    "## " + ROBIN_SIGNATURE,
     "",
     `:arrows_counterclockwise: This ${command === "summary" ? "summary" : "review"} run was replaced by a newer Robin run on this pull request.`,
     "",
@@ -527,7 +532,7 @@ function buildSupersededStatusBody(command: "review" | "summary"): string {
 
 function buildCancelledStatusBody(command: "review" | "summary"): string {
   return [
-    "## :bow_and_arrow: Robin",
+    "## " + ROBIN_SIGNATURE,
     "",
     `:warning: The ${command === "summary" ? "summary" : "review"} was interrupted before it finished.`,
     "",

--- a/src/main.ts
+++ b/src/main.ts
@@ -142,7 +142,8 @@ async function run(): Promise<void> {
     onJobCancelled = async () => {
       if (octokit && statusCommentId) {
         // The SIGTERM grace period is short — never let the superseded check
-        // delay the status update past it.
+        // delay the status update past it. On timeout the check is abandoned
+        // fire-and-forget; its own try/catch swallows any late rejection.
         const superseded = await Promise.race([
           isSupersededByNewerRun(octokit, statusOwner, statusRepo),
           new Promise<boolean>((resolve) => setTimeout(() => resolve(false), 3000).unref()),
@@ -502,14 +503,18 @@ async function isSupersededByNewerRun(octokit: any, owner: string, repo: string)
       run_id: runId,
     });
 
-    for (const status of ["queued", "in_progress"] as const) {
-      const { data } = await octokit.rest.actions.listWorkflowRuns({
-        owner,
-        repo,
-        workflow_id: currentRun.workflow_id,
-        status,
-        per_page: 30,
-      });
+    const results = await Promise.all(
+      (["queued", "in_progress"] as const).map((status) =>
+        octokit.rest.actions.listWorkflowRuns({
+          owner,
+          repo,
+          workflow_id: currentRun.workflow_id,
+          status,
+          per_page: 30,
+        })
+      )
+    );
+    for (const { data } of results) {
       if (data.workflow_runs.some((run: any) => run.id !== runId && run.run_number > currentRun.run_number)) {
         return true;
       }

--- a/src/main.ts
+++ b/src/main.ts
@@ -488,8 +488,8 @@ function buildProgressStatusBody(
  * True when a newer run of this same workflow is queued or in progress —
  * i.e. this run was cancelled by concurrency `cancel-in-progress`, not by a
  * human or a timeout. Best-effort: any API failure returns false.
- * ponytail: may match a newer run on a different PR; acceptable — it only
- * softens the wording of a cancel notice, upgrade to per-PR matching if needed.
+ * Note: may match a newer run on a different PR; acceptable — it only
+ * softens the wording of a cancel notice. Upgrade to per-PR matching if needed.
  */
 async function isSupersededByNewerRun(octokit: any, owner: string, repo: string): Promise<boolean> {
   try {
@@ -524,9 +524,9 @@ function buildSupersededStatusBody(command: "review" | "summary"): string {
   return [
     "## " + ROBIN_SIGNATURE,
     "",
-    `:arrows_counterclockwise: This ${command === "summary" ? "summary" : "review"} run was replaced by a newer Robin run on this pull request.`,
+    `:arrows_counterclockwise: This ${command === "summary" ? "summary" : "review"} run was replaced by a newer Robin run.`,
     "",
-    "No action needed — the newer run's comment below has the result.",
+    "No action needed — the newer run posts its own result when it finishes.",
   ].join("\n");
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -141,12 +141,15 @@ async function run(): Promise<void> {
     statusCommentId = await postStatusComment(octokit, owner, repo, prNumber, command, statusModel);
     onJobCancelled = async () => {
       if (octokit && statusCommentId) {
+        const superseded = await isSupersededByNewerRun(octokit, statusOwner, statusRepo);
         await updateStatusComment(
           octokit,
           statusOwner,
           statusRepo,
           statusCommentId,
-          buildCancelledStatusBody(statusCommand)
+          superseded
+            ? buildSupersededStatusBody(statusCommand)
+            : buildCancelledStatusBody(statusCommand)
         );
       }
     };
@@ -473,6 +476,52 @@ function buildProgressStatusBody(
     "",
     `Mode: ${command === "summary" ? "summary" : "code review"}`,
     `Model: ${model}`,
+  ].join("\n");
+}
+
+/**
+ * True when a newer run of this same workflow is queued or in progress —
+ * i.e. this run was cancelled by concurrency `cancel-in-progress`, not by a
+ * human or a timeout. Best-effort: any API failure returns false.
+ * ponytail: may match a newer run on a different PR; acceptable — it only
+ * softens the wording of a cancel notice, upgrade to per-PR matching if needed.
+ */
+async function isSupersededByNewerRun(octokit: any, owner: string, repo: string): Promise<boolean> {
+  try {
+    const runId = Number(process.env.GITHUB_RUN_ID);
+    if (!runId) return false;
+
+    const { data: currentRun } = await octokit.rest.actions.getWorkflowRun({
+      owner,
+      repo,
+      run_id: runId,
+    });
+
+    for (const status of ["queued", "in_progress"] as const) {
+      const { data } = await octokit.rest.actions.listWorkflowRuns({
+        owner,
+        repo,
+        workflow_id: currentRun.workflow_id,
+        status,
+        per_page: 30,
+      });
+      if (data.workflow_runs.some((run: any) => run.id !== runId && run.run_number > currentRun.run_number)) {
+        return true;
+      }
+    }
+  } catch (error) {
+    core.warning(`Could not check for a superseding run: ${error}`);
+  }
+  return false;
+}
+
+function buildSupersededStatusBody(command: "review" | "summary"): string {
+  return [
+    "## :bow_and_arrow: Robin",
+    "",
+    `:arrows_counterclockwise: This ${command === "summary" ? "summary" : "review"} run was replaced by a newer Robin run on this pull request.`,
+    "",
+    "No action needed — the newer run's comment below has the result.",
   ].join("\n");
 }
 


### PR DESCRIPTION
## Problem

Seen on antongulin/n8n#71: a `/robin` comment 1s after PR creation triggered `cancel-in-progress`, the cancelled run posted **"interrupted — comment `/robin` to run again"**, the user obeyed, which cancelled the *healthy* run 2s after it had submitted a `CHANGES_REQUESTED` review — leaving a stale blocking review from a dead run plus a duplicate review from the superseding run.

## Fixes

1. **Superseded cancel notice** — on SIGTERM, Robin checks whether a newer run of the same workflow is queued/in progress. If so, the status comment says the run was **replaced by a newer Robin run** (no re-trigger advice); only genuinely interrupted runs keep the old "comment `/robin` to run again" message.
2. **Dismiss stale Robin reviews** — after posting a review, Robin dismisses its own earlier `CHANGES_REQUESTED` reviews (matched by the `:bow_and_arrow: Robin` body marker; human reviews untouched) so a stale blocking review can't keep gating the PR.

Both are best-effort: any API failure falls back to the previous behavior with a warning.

## Verification

- `npm run lint` ✅, `npm test` — 63/63 ✅, `npm run build` (dist committed) ✅
- New unit test for `isStaleRobinReview` (own-review, non-blocking, human-review, null-body cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)