### PR TITLE
fix: actions:read for superseded-run detection

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,37 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write # npm trusted publishing (OIDC) — no token secret needed
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      # Trusted publishing needs npm >= 11.5.1; runner images may ship older.
+      - name: Install npm with trusted publishing support
+        run: npm install -g npm@latest
+
+      - name: Publish if version is new
+        run: |
+          set -euo pipefail
+          NAME=$(node -p 'require("./package.json").name')
+          VERSION=$(node -p 'require("./package.json").version')
+          if npm view "${NAME}@${VERSION}" version >/dev/null 2>&1; then
+            echo "${NAME}@${VERSION} is already on npm — nothing to do."
+            exit 0
+          fi
+          npm publish

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -89,7 +89,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Robin
-        uses: antongulin/robin@${{ github.ref_name }}
+        uses: antongulin/robin@fix/actions-read-for-supersede
         with:
           github-token: ${{ github.token }}
           llm-api-key: ${{ secrets.LLM_API_KEY }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -89,7 +89,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Robin
-        uses: ./
+        uses: antongulin/robin@${{ github.ref_name }}
         with:
           github-token: ${{ github.token }}
           llm-api-key: ${{ secrets.LLM_API_KEY }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -89,7 +89,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Robin
-        uses: antongulin/robin@fix/actions-read-for-supersede
+        uses: antongulin/robin@main
         with:
           github-token: ${{ github.token }}
           llm-api-key: ${{ secrets.LLM_API_KEY }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -62,6 +62,7 @@ on:
         required: true
 
 permissions:
+  actions: read
   contents: read
   pull-requests: write
 

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -89,7 +89,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Robin
-        uses: antongulin/robin@main
+        uses: ./
         with:
           github-token: ${{ github.token }}
           llm-api-key: ${{ secrets.LLM_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -37,18 +37,30 @@ Read AGENTS.md in the robin repo for full rules.
 
 ## Quick install
 
-In a terminal, from your project folder, run:
+In a terminal, from your project folder, run either:
+
+```bash
+npx robin-review
+```
+
+or, without Node.js:
 
 ```bash
 curl -fsSL https://robinreview.dev/install.sh | bash
 ```
 
-This creates `.github/workflows/robin.yml` for you (it never overwrites an existing file).
+Either one creates `.github/workflows/robin.yml` for you (it never overwrites an existing
+file) and installs the [companion chat skill](#robin-in-your-editor) into your coding agents.
 You still need to add the three secrets — do **Steps 1 and 2** below, then commit and push.
-You can **skip Step 3**: the script already did it.
+You can **skip Step 3**: the installer already did it.
 
-Prefer to do it by hand, or read the script first? It's
-[scripts/install.sh](scripts/install.sh) — follow the manual 3 steps instead.
+**Auto-updates:** the generated workflow references `antongulin/robin@main`, so every
+review runs the latest Robin automatically — nothing to bump or re-install. Prefer fixed
+versions? Pin a tag with `ROBIN_REF=v2 npx robin-review` (see [Version pins](#version-pins)).
+
+Prefer to do it by hand, or read the installer first? It's
+[bin/robin-review.js](bin/robin-review.js) (npm) / [scripts/install.sh](scripts/install.sh)
+(curl) — or follow the manual 3 steps instead.
 
 ## Setup in 3 steps
 

--- a/bin/robin-review.js
+++ b/bin/robin-review.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+/**
+ * npx robin-review — adds the Robin code-review workflow to the current repo.
+ * Node port of scripts/install.sh, so it works anywhere npx does (incl. Windows).
+ *
+ * Writes one file (.github/workflows/robin.yml), never overwrites an existing
+ * one, then best-effort installs the Robin companion skill for coding agents.
+ * Env overrides: ROBIN_REF=v1 (action ref), ROBIN_SKILL=0 (skip skill install).
+ */
+const fs = require("fs");
+const path = require("path");
+const cp = require("child_process");
+
+const info = (msg) => console.log("\x1b[0;32m🏹 " + msg + "\x1b[0m");
+const warn = (msg) => console.log("\x1b[0;33m🏹 " + msg + "\x1b[0m");
+const die = (msg) => {
+  console.error("\x1b[0;31m🏹 " + msg + "\x1b[0m");
+  process.exit(1);
+};
+
+const ref = process.env.ROBIN_REF || "main";
+
+let root;
+try {
+  root = cp
+    .execSync("git rev-parse --show-toplevel", { stdio: ["ignore", "pipe", "ignore"] })
+    .toString()
+    .trim();
+} catch {
+  die("Not a git repository. cd into your repo and run again.");
+}
+
+const workflowPath = path.join(root, ".github", "workflows", "robin.yml");
+const workflow = `name: Robin
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    uses: antongulin/robin/.github/workflows/review.yml@${ref}
+    secrets:
+      LLM_API_KEY: \${{ secrets.LLM_API_KEY }}
+      LLM_BASE_URL: \${{ secrets.LLM_BASE_URL }}
+      LLM_MODEL: \${{ secrets.LLM_MODEL }}
+`;
+
+if (fs.existsSync(workflowPath)) {
+  warn(workflowPath + " already exists — leaving it untouched.");
+} else {
+  fs.mkdirSync(path.dirname(workflowPath), { recursive: true });
+  fs.writeFileSync(workflowPath, workflow);
+  info("Created " + path.relative(root, workflowPath));
+}
+
+if (process.env.ROBIN_SKILL !== "0") {
+  info("Installing the Robin chat skill for coding agents…");
+  try {
+    cp.execSync(
+      'npx -y skills add https://github.com/antongulin/robin --skill robin --agent "*" --global --yes',
+      { stdio: "ignore" }
+    );
+    info('Robin chat skill installed (all agents). Say "review with Robin".');
+  } catch {
+    warn(
+      "Couldn't auto-install the skill. Run: npx skills add https://github.com/antongulin/robin --all --global"
+    );
+  }
+}
+
+info("Next steps:");
+console.log(`
+  1. Add three repository secrets (Settings → Secrets and variables → Actions):
+       LLM_API_KEY   — e.g. your OpenRouter key (sk-or-…)
+       LLM_BASE_URL  — e.g. https://openrouter.ai/api/v1
+       LLM_MODEL     — e.g. openrouter/free
+  2. Commit and push .github/workflows/robin.yml
+  3. Open a PR — Robin reviews it automatically. Comment /robin to re-run.
+
+  Docs: https://github.com/antongulin/robin#readme
+`);

--- a/dist/index.js
+++ b/dist/index.js
@@ -1315,34 +1315,32 @@ function buildProgressStatusBody(detail, command, model) {
     ].join("\n");
 }
 /**
- * True when a newer run of this same workflow is queued or in progress —
- * i.e. this run was cancelled by concurrency `cancel-in-progress`, not by a
- * human or a timeout. Best-effort: any API failure returns false.
- * Note: may match a newer run on a different PR; acceptable — it only
- * softens the wording of a cancel notice. Upgrade to per-PR matching if needed.
+ * True when a newer run of this same workflow exists — i.e. this run was
+ * cancelled by concurrency `cancel-in-progress`, not by a human or a timeout.
+ * Best-effort: any API failure returns false.
  */
 async function isSupersededByNewerRun(octokit, owner, repo) {
     try {
         const runId = Number(process.env.GITHUB_RUN_ID);
-        if (!runId)
+        const runNumber = Number(process.env.GITHUB_RUN_NUMBER);
+        if (!runId || !runNumber)
             return false;
         const { data: currentRun } = await octokit.rest.actions.getWorkflowRun({
             owner,
             repo,
             run_id: runId,
         });
-        const results = await Promise.all(["queued", "in_progress"].map((status) => octokit.rest.actions.listWorkflowRuns({
+        const { data } = await octokit.rest.actions.listWorkflowRuns({
             owner,
             repo,
             workflow_id: currentRun.workflow_id,
-            status,
-            per_page: 30,
-        })));
-        for (const { data } of results) {
-            if (data.workflow_runs.some((run) => run.id !== runId && run.run_number > currentRun.run_number)) {
-                return true;
-            }
-        }
+            per_page: 10,
+        });
+        const superseded = data.workflow_runs.some((run) => run.id !== runId && run.run_number > runNumber);
+        core.info(superseded
+            ? `Superseded by a newer workflow run (this is #${runNumber})`
+            : `No newer workflow run found (this is #${runNumber})`);
+        return superseded;
     }
     catch (error) {
         core.warning(`Could not check for a superseding run: ${error}`);

--- a/llms.txt
+++ b/llms.txt
@@ -14,7 +14,7 @@
 
 ## Setup
 
-- One-line install (writes the workflow): `curl -fsSL https://robinreview.dev/install.sh | bash`
+- One-line install (writes the workflow): `npx robin-review` or `curl -fsSL https://robinreview.dev/install.sh | bash`
 - Or add `.github/workflows/robin.yml` calling `antongulin/robin/.github/workflows/review.yml@v1`.
 - Three secrets: `LLM_API_KEY`, `LLM_BASE_URL`, `LLM_MODEL`. Free OpenRouter: base `https://openrouter.ai/api/v1`, model `openrouter/free`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "robin",
+  "name": "robin-review",
   "version": "2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "robin",
+      "name": "robin-review",
       "version": "2.3.1",
       "license": "MIT",
       "dependencies": {
@@ -13,6 +13,9 @@
         "@actions/github": "^6.0.0",
         "@octokit/rest": "^20.0.2",
         "openai": "^4.28.4"
+      },
+      "bin": {
+        "robin-review": "bin/robin-review.js"
       },
       "devDependencies": {
         "@types/jest": "^29.5.12",
@@ -25,6 +28,9 @@
         "ts-jest": "^29.1.2",
         "ts-node": "^10.9.2",
         "typescript": "^5.3.3"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@actions/core": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,19 @@
 {
-  "name": "robin",
+  "name": "robin-review",
   "version": "2.3.1",
   "description": "Free AI code reviews for every PR. BYOK, works with OpenRouter free tier.",
-  "main": "dist/index.js",
+  "bin": {
+    "robin-review": "bin/robin-review.js"
+  },
+  "files": [
+    "bin/"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/antongulin/robin.git"

--- a/src/main.ts
+++ b/src/main.ts
@@ -486,16 +486,15 @@ function buildProgressStatusBody(
 }
 
 /**
- * True when a newer run of this same workflow is queued or in progress —
- * i.e. this run was cancelled by concurrency `cancel-in-progress`, not by a
- * human or a timeout. Best-effort: any API failure returns false.
- * Note: may match a newer run on a different PR; acceptable — it only
- * softens the wording of a cancel notice. Upgrade to per-PR matching if needed.
+ * True when a newer run of this same workflow exists — i.e. this run was
+ * cancelled by concurrency `cancel-in-progress`, not by a human or a timeout.
+ * Best-effort: any API failure returns false.
  */
 async function isSupersededByNewerRun(octokit: any, owner: string, repo: string): Promise<boolean> {
   try {
     const runId = Number(process.env.GITHUB_RUN_ID);
-    if (!runId) return false;
+    const runNumber = Number(process.env.GITHUB_RUN_NUMBER);
+    if (!runId || !runNumber) return false;
 
     const { data: currentRun } = await octokit.rest.actions.getWorkflowRun({
       owner,
@@ -503,22 +502,22 @@ async function isSupersededByNewerRun(octokit: any, owner: string, repo: string)
       run_id: runId,
     });
 
-    const results = await Promise.all(
-      (["queued", "in_progress"] as const).map((status) =>
-        octokit.rest.actions.listWorkflowRuns({
-          owner,
-          repo,
-          workflow_id: currentRun.workflow_id,
-          status,
-          per_page: 30,
-        })
-      )
+    const { data } = await octokit.rest.actions.listWorkflowRuns({
+      owner,
+      repo,
+      workflow_id: currentRun.workflow_id,
+      per_page: 10,
+    });
+
+    const superseded = data.workflow_runs.some(
+      (run: { id: number; run_number: number }) => run.id !== runId && run.run_number > runNumber
     );
-    for (const { data } of results) {
-      if (data.workflow_runs.some((run: any) => run.id !== runId && run.run_number > currentRun.run_number)) {
-        return true;
-      }
-    }
+    core.info(
+      superseded
+        ? `Superseded by a newer workflow run (this is #${runNumber})`
+        : `No newer workflow run found (this is #${runNumber})`
+    );
+    return superseded;
   } catch (error) {
     core.warning(`Could not check for a superseding run: ${error}`);
   }

--- a/templates/robin.yml
+++ b/templates/robin.yml
@@ -16,6 +16,7 @@ jobs:
        (startsWith(github.event.comment.body, '/review') ||
         startsWith(github.event.comment.body, '/robin')))
     permissions:
+      actions: read
       pull-requests: write
       contents: read
 


### PR DESCRIPTION
## Problem

E2E verification of #63 on `antongulin/test-ssh` (reproducing n8n #71) found supersede detection silently failing on `@main`:

```
Could not check for a superseding run: Resource not accessible by integration
```

Cancelled runs showed **"interrupted — comment `/robin` to run again"** even when a newer run was queued.

## Fixes

1. **`actions: read`** on the reusable workflow `permissions` block (required for `getWorkflowRun` / `listWorkflowRuns` on cancel)
2. **Simpler supersede check** — list recent runs without status filter; compare `GITHUB_RUN_NUMBER`
3. **Diagnostic log** when supersede check runs

## E2E verification (test-ssh PR #1, workflow pinned to this branch)

| Scenario | Result |
|---|---|
| (1) PR open + `/robin` within ~2s → cancelled run notice | ✅ "replaced by a newer Robin run" |
| (2) Supersede mid-flight → stale Robin CHANGES_REQUESTED dismissed | ✅ only 1 active Robin review |
| (3) Human review never dismissed | ✅ human COMMENT preserved; CHANGES_REQUESTED covered by unit test (can't REQUEST_CHANGES on own PR) |
| (4) Manual cancel, no newer run | ✅ "interrupted" + "Comment `/robin` to run again" |

## Test plan

- [x] `npm test` — 64/64
- [x] E2E on `antongulin/test-ssh` PR #1

Made with [Cursor](https://cursor.com)