### PR TITLE
fix: dispatch npm publish after auto-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      actions: write
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       RELEASE_PENDING_LABEL: "autorelease: pending"
@@ -221,3 +222,10 @@ jobs:
             echo "Failed to $label_action on release PR #$number." >&2
             exit 1
           fi
+
+      # Releases created with GITHUB_TOKEN don't trigger `release:` workflows
+      # (GitHub recursion guard). workflow_dispatch is exempt, so kick off the
+      # npm publish explicitly.
+      - name: Dispatch npm publish
+        shell: bash
+        run: gh workflow run publish.yml --ref main


### PR DESCRIPTION
v2.4.0 was released but the new `Publish to npm` workflow never ran: the release is created with `GITHUB_TOKEN`, and events from that token don't trigger other workflows (GitHub recursion guard). `workflow_dispatch` is exempt, so the auto-release job now dispatches `publish.yml` explicitly after tagging (needs `actions: write`).

Verified the mechanism manually: `gh workflow run publish.yml` fired the workflow for v2.4.0 (run 28967732783 — OIDC/provenance worked; it 404'd only because the npm trusted publisher for the new package isn't configured yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)