### PR TITLE
fix: grant actions:read for superseded-run detection

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -62,7 +62,7 @@ on:
         required: true
 
 permissions:
-  actions: read
+  actions: read # lets Robin detect when a cancelled run was superseded by a newer one
   contents: read
   pull-requests: write
 

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -62,6 +62,7 @@ on:
         required: true
 
 permissions:
+  actions: read
   contents: read
   pull-requests: write
 
@@ -88,7 +89,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Robin
-        uses: ./
+        uses: antongulin/robin@main
         with:
           github-token: ${{ github.token }}
           llm-api-key: ${{ secrets.LLM_API_KEY }}

--- a/templates/robin.yml
+++ b/templates/robin.yml
@@ -16,7 +16,7 @@ jobs:
        (startsWith(github.event.comment.body, '/review') ||
         startsWith(github.event.comment.body, '/robin')))
     permissions:
-      actions: read
+      actions: read # lets Robin detect when a cancelled run was superseded by a newer one
       pull-requests: write
       contents: read
 

--- a/templates/robin.yml
+++ b/templates/robin.yml
@@ -16,6 +16,7 @@ jobs:
        (startsWith(github.event.comment.body, '/review') ||
         startsWith(github.event.comment.body, '/robin')))
     permissions:
+      actions: read
       pull-requests: write
       contents: read
 


### PR DESCRIPTION
Clean respin of #66 on top of current main (that branch predated the #65 squash-merge and carried 6 stale/duplicate commits).

Net changes:
- `.github/workflows/review.yml`: add `actions: read` — the superseded-run check (`isSupersededByNewerRun`) calls the Actions API during cancel; without this permission it always fails and cancelled runs show the generic "interrupted" message instead of the superseded notice.
- `.github/workflows/review.yml`: revert `uses: ./` → `uses: antongulin/robin@main` — `./` doesn't resolve for external callers of the reusable workflow (E2E-tested on the original branch).
- `templates/robin.yml`: same `actions: read` for direct-action users.

Credit: fix authored by the Cursor session on `fix/actions-read-for-supersede`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)