### PR TITLE
fix: expose request-changes on reusable review workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,5 +12,14 @@ Briefly: what this changes and the reason.
 - [ ] `npm test`
 - [ ] `npm run build` (run before committing — `dist/index.js` is the published bundle)
 
+**Dual entry points** (required when adding/changing an action input)
+Robin has two surfaces. Updating only `action.yml` is not enough for most consumers.
+
+- [ ] `action.yml` input added/updated
+- [ ] `.github/workflows/review.yml` `workflow_call` input + forward to the action step
+- [ ] `.github/robin.yml` / repo-config parser (if the knob should be set without a workflow edit)
+- [ ] `docs/ADVANCED.md` + example if user-facing
+- [ ] `testdata/consumer-workflows/all-inputs.yml` updated (actionlint + Jest parity)
+
 **Notes**
 Breaking change? Migration needed? Anything reviewers should focus on?

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -8,6 +8,11 @@ on:
         required: false
         type: boolean
         default: false
+      request-changes:
+        description: "Whether a high severity finding submits a blocking REQUEST_CHANGES review. true posts REQUEST_CHANGES; false always posts COMMENT (advisor mode). Leave empty to use the repo config, which defaults to true."
+        required: false
+        type: string
+        default: ""
       max-diff-size:
         description: "Maximum diff characters sent to the model."
         required: false
@@ -48,6 +53,16 @@ on:
         required: false
         type: boolean
         default: false
+      config-file:
+        description: "Optional repository config file on the PR base branch."
+        required: false
+        type: string
+        default: ".github/robin.yml"
+      use-json-response-mode:
+        description: "Request JSON object responses when the provider supports response_format. Leave empty to use repo config or default true."
+        required: false
+        type: string
+        default: ""
       runner:
         description: "Runner label or JSON array of labels to use for the review job."
         required: false
@@ -96,6 +111,7 @@ jobs:
           llm-base-url: ${{ secrets.LLM_BASE_URL }}
           model: ${{ secrets.LLM_MODEL }}
           fail-on-high: ${{ inputs.fail-on-high }}
+          request-changes: ${{ inputs.request-changes }}
           max-diff-size: ${{ inputs.max-diff-size }}
           max-comments: ${{ inputs.max-comments }}
           max-output-tokens: ${{ inputs.max-output-tokens }}
@@ -104,3 +120,5 @@ jobs:
           review-instructions: ${{ inputs.review-instructions }}
           review-instructions-file: ${{ inputs.review-instructions-file }}
           review-on-synchronize: ${{ inputs.review-on-synchronize }}
+          config-file: ${{ inputs.config-file }}
+          use-json-response-mode: ${{ inputs.use-json-response-mode }}

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -9,10 +9,11 @@ on:
         type: boolean
         default: false
       request-changes:
-        description: "Whether a high severity finding submits a blocking REQUEST_CHANGES review. true posts REQUEST_CHANGES; false always posts COMMENT (advisor mode). Leave empty to use the repo config, which defaults to true."
+        description: "Whether a high severity finding submits a blocking REQUEST_CHANGES review. true posts REQUEST_CHANGES; false always posts COMMENT (advisor mode). Omit to use the repo config, which defaults to true."
         required: false
-        type: string
-        default: ""
+        type: boolean
+        # No default: omitted must stay unset so .github/robin.yml can still win.
+        # A boolean default of true would override repo-config advisor mode.
       max-diff-size:
         description: "Maximum diff characters sent to the model."
         required: false

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -32,7 +32,18 @@ jobs:
         run: npm run lint
 
       - name: Install actionlint
-        run: bash <(curl -sL https://raw.githubusercontent.com/rhysd/actionlint/v1.7.12/scripts/download-actionlint.bash) 1.7.12
+        # Pin version + SHA256 of the linux_amd64 release tarball (no curl|bash).
+        env:
+          ACTIONLINT_VERSION: "1.7.12"
+          ACTIONLINT_SHA256: "8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
+        run: |
+          set -euo pipefail
+          archive="actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+          curl -sSL -o "$archive" \
+            "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${archive}"
+          echo "${ACTIONLINT_SHA256}  ${archive}" | sha256sum -c -
+          tar -xzf "$archive" actionlint
+          ./actionlint -version
 
       - name: Lint workflows
         # Catches undeclared workflow_call inputs the same way GitHub does for

--- a/.github/workflows/self-test.yml
+++ b/.github/workflows/self-test.yml
@@ -30,6 +30,15 @@ jobs:
       
       - name: Lint
         run: npm run lint
+
+      - name: Install actionlint
+        run: bash <(curl -sL https://raw.githubusercontent.com/rhysd/actionlint/v1.7.12/scripts/download-actionlint.bash) 1.7.12
+
+      - name: Lint workflows
+        # Catches undeclared workflow_call inputs the same way GitHub does for
+        # consumers (e.g. request-changes missing from review.yml). Also lints
+        # testdata/consumer-workflows fixtures that pass every reusable input.
+        run: ./actionlint -shellcheck= -pyflakes= .github/workflows/*.yml testdata/consumer-workflows/*.yml
        
       - name: Test
         run: npm test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,24 @@ helps a strong model can quietly regress a weak one, so test against more than o
 - Update the README when changing user-facing inputs or behavior.
 - Do not commit secrets, provider keys, or private endpoint URLs.
 
+### Dual entry points (action inputs)
+
+Most consumers call the reusable workflow, not the action directly:
+
+```yaml
+uses: antongulin/robin/.github/workflows/review.yml@main
+```
+
+When you add or change an action input:
+
+1. Declare it in `action.yml`.
+2. Declare it under `on.workflow_call.inputs` in `.github/workflows/review.yml` and forward it to the action step.
+3. If it should be settable without editing the workflow, parse it in `.github/robin.yml` (see `src/repo-config.ts`).
+4. Document it in `docs/ADVANCED.md`.
+5. Update `testdata/consumer-workflows/all-inputs.yml` so actionlint + the Jest parity test stay green.
+
+CI runs [actionlint](https://github.com/rhysd/actionlint) on workflows and that consumer fixture — the same class of error GitHub returns for an undeclared `with:` input.
+
 ## Commit messages (for releases)
 
 Merges to `main` use [Release Please](https://github.com/googleapis/release-please) to bump versions and write release notes. Use [Conventional Commits](https://www.conventionalcommits.org/) in PR titles or squash-merge messages:

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -110,7 +110,7 @@ Available on the [direct action](../action.yml) and the [reusable workflow](../.
 | `llm-base-url` / `LLM_BASE_URL` | — | OpenAI-compatible base URL (required) |
 | `model` / `LLM_MODEL` | — | Model name (required) |
 | `fail-on-high` | `false` | Fail the check if high-severity issues are found |
-| `request-changes` | empty → `true` (defer to repo config) | `true` submits a blocking REQUEST_CHANGES review on high findings; `false` posts a non-blocking COMMENT (advisor mode). Pass `"true"` / `"false"` on the reusable workflow (string input so empty still defers to `.github/robin.yml`) |
+| `request-changes` | omit → `true` (defer to repo config) | `true` submits a blocking REQUEST_CHANGES review on high findings; `false` posts a non-blocking COMMENT (advisor mode). Reusable workflow input is a boolean with no default — omit it to let `.github/robin.yml` win |
 | `max-diff-size` | `50000` | Max diff characters sent to the model |
 | `max-output-tokens` | empty | Cap response tokens (optional) |
 | `llm-timeout-ms` | `600000` | LLM timeout (10 minutes) |
@@ -139,7 +139,7 @@ jobs:
   review:
     uses: antongulin/robin/.github/workflows/review.yml@main
     with:
-      request-changes: false   # string input; bare false / "false" both work
+      request-changes: false   # boolean; omit this line to defer to .github/robin.yml
     secrets:
       LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
       LLM_BASE_URL: ${{ secrets.LLM_BASE_URL }}

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -18,7 +18,7 @@ skip-paths:
 | Key | Purpose |
 | --- | --- |
 | `max-diff-size` | Used when the workflow still passes the action default (`50000`) |
-| `max-comments` | Used when the workflow passes action default `25` or reusable workflow default `10` |
+| `max-comments` | Used when the workflow still passes the action default (`15`) |
 | `json-response-mode` | Used when `use-json-response-mode` is empty (action default defers to this file) |
 | `request-changes` | Used when `request-changes` input is empty. `true` (default) blocks on high findings; `false` posts advisor-only comments |
 | `skip-paths` | Extra paths removed from the diff before the LLM call |
@@ -101,29 +101,50 @@ jobs:
 
 ## All workflow inputs
 
-Available on the [direct action](../action.yml) and the [reusable workflow](../.github/workflows/review.yml).
+Available on the [direct action](../action.yml) and the [reusable workflow](../.github/workflows/review.yml), unless noted. LLM credentials are action inputs / reusable-workflow secrets respectively.
 
 | Input | Default | Description |
 | --- | --- | --- |
-| `github-token` | `${{ github.token }}` | Token for PR API and comments |
-| `llm-api-key` | `ollama` | Provider API key |
-| `llm-base-url` | — | OpenAI-compatible base URL (required) |
-| `model` | — | Model name (required) |
+| `github-token` | `${{ github.token }}` | Token for PR API and comments (direct action only; reusable workflow uses `github.token`) |
+| `llm-api-key` / `LLM_API_KEY` | `ollama` | Provider API key |
+| `llm-base-url` / `LLM_BASE_URL` | — | OpenAI-compatible base URL (required) |
+| `model` / `LLM_MODEL` | — | Model name (required) |
 | `fail-on-high` | `false` | Fail the check if high-severity issues are found |
-| `request-changes` | empty → `true` (defer to repo config) | `true` submits a blocking REQUEST_CHANGES review on high findings; `false` posts a non-blocking COMMENT (advisor mode) |
+| `request-changes` | empty → `true` (defer to repo config) | `true` submits a blocking REQUEST_CHANGES review on high findings; `false` posts a non-blocking COMMENT (advisor mode). Pass `"true"` / `"false"` on the reusable workflow (string input so empty still defers to `.github/robin.yml`) |
 | `max-diff-size` | `50000` | Max diff characters sent to the model |
 | `max-output-tokens` | empty | Cap response tokens (optional) |
 | `llm-timeout-ms` | `600000` | LLM timeout (10 minutes) |
-| `max-comments` | `25` (action) / `10` (reusable workflow) | Max inline comments |
+| `max-comments` | `15` | Max inline comments |
 | `review-on-synchronize` | `false` | Review every new commit on the PR |
-| `runner` | `'"ubuntu-latest"'` | Reusable workflow runner as a JSON string or JSON array |
+| `runner` | `'"ubuntu-latest"'` | Reusable workflow only: runner as a JSON string or JSON array |
 | `min-command-permission` | `write` | Who can run `/review` |
 | `review-instructions` | empty | Extra prompt text |
 | `review-instructions-file` | `.github/code-reviewer.md` | Rules file on the base branch |
 | `config-file` | `.github/robin.yml` | Repo config path on the base branch |
-| `use-json-response-mode` | empty (defer to repo config, else true) | Request `response_format: json_object` when supported |
+| `use-json-response-mode` | empty (defer to repo config, else true) | Request `response_format: json_object` when supported. Pass `"true"` / `"false"` on the reusable workflow |
 
 ## Usage patterns
+
+### Advisor mode (never block the PR)
+
+Useful when Robin is an assistant and humans own merge decisions. Prefer `.github/robin.yml` for repo-wide defaults; use the workflow input to override per workflow:
+
+```yaml
+# .github/robin.yml
+request-changes: false
+```
+
+```yaml
+jobs:
+  review:
+    uses: antongulin/robin/.github/workflows/review.yml@main
+    with:
+      request-changes: "false"
+    secrets:
+      LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+      LLM_BASE_URL: ${{ secrets.LLM_BASE_URL }}
+      LLM_MODEL: ${{ secrets.LLM_MODEL }}
+```
 
 ### Review on every commit
 

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -139,7 +139,7 @@ jobs:
   review:
     uses: antongulin/robin/.github/workflows/review.yml@main
     with:
-      request-changes: "false"
+      request-changes: false   # string input; bare false / "false" both work
     secrets:
       LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
       LLM_BASE_URL: ${{ secrets.LLM_BASE_URL }}

--- a/src/workflow.test.ts
+++ b/src/workflow.test.ts
@@ -26,6 +26,27 @@ describe("reusable review workflow", () => {
     expect(workflow).toContain("startsWith(github.event.comment.body, '/review')");
   });
 
+  it("exposes every non-secret action input through workflow_call and forwards it", () => {
+    // Secrets / token are wired separately; runner is workflow-only.
+    const actionOnlySecrets = new Set([
+      "github-token",
+      "llm-api-key",
+      "llm-base-url",
+      "model",
+    ]);
+    const action = readFileSync(join(repoRoot, "action.yml"), "utf8");
+    const actionInputs = [
+      ...action.matchAll(/^  ([a-z0-9-]+):\n    description:/gm),
+    ].map((match) => match[1]);
+    const publicInputs = actionInputs.filter((name) => !actionOnlySecrets.has(name));
+
+    const workflowCallSection = reviewWorkflow.split("secrets:")[0];
+    for (const name of publicInputs) {
+      expect(workflowCallSection).toContain(`      ${name}:`);
+      expect(reviewWorkflow).toContain(`${name}: \${{ inputs.${name} }}`);
+    }
+  });
+
   it("lets callers choose a GitHub-hosted or self-hosted runner", () => {
     expect(reviewWorkflow).toContain("runner:");
     expect(reviewWorkflow).toContain(

--- a/src/workflow.test.ts
+++ b/src/workflow.test.ts
@@ -29,8 +29,14 @@ const ACTION_ONLY_SECRETS = new Set([
 /** Workflow-only input (not an action input). */
 const WORKFLOW_ONLY_INPUTS = new Set(["runner"]);
 
-/** Empty default means "defer to .github/robin.yml" — must stay string, not boolean. */
-const DEFER_TO_CONFIG_INPUTS = ["request-changes", "use-json-response-mode"] as const;
+/**
+ * Defer-to-config knobs must not force a boolean default of true/false on the
+ * reusable workflow — that would override `.github/robin.yml`.
+ * - request-changes: boolean, no default (omit → empty → repo config)
+ * - use-json-response-mode: string, default ""
+ */
+const DEFER_BOOLEAN_NO_DEFAULT = ["request-changes"] as const;
+const DEFER_STRING_EMPTY_DEFAULT = ["use-json-response-mode"] as const;
 
 function parseActionInputs(source: string): string[] {
   // Scope to the inputs: section so a future outputs: block cannot pollute parity.
@@ -139,8 +145,15 @@ describe("reusable review workflow", () => {
     ]);
   });
 
-  it("keeps defer-to-config knobs as empty-default strings (not booleans)", () => {
-    for (const name of DEFER_TO_CONFIG_INPUTS) {
+  it("keeps defer-to-config knobs from forcing a boolean default", () => {
+    for (const name of DEFER_BOOLEAN_NO_DEFAULT) {
+      const block = workflowCallInputBlock(reviewWorkflow, name);
+      expect(block).toBeDefined();
+      expect(block).toContain("type: boolean");
+      // Ignore comments that mention "default"; only a real YAML key would break deferral.
+      expect(block).not.toMatch(/^\s*default:/m);
+    }
+    for (const name of DEFER_STRING_EMPTY_DEFAULT) {
       const block = workflowCallInputBlock(reviewWorkflow, name);
       expect(block).toBeDefined();
       expect(block).toContain("type: string");

--- a/src/workflow.test.ts
+++ b/src/workflow.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from "fs";
+import { readFileSync, readdirSync } from "fs";
 import { join } from "path";
 
 const repoRoot = join(__dirname, "..");
@@ -12,9 +12,84 @@ const selfTestWorkflow = readFileSync(
 );
 const robinTemplate = readFileSync(join(repoRoot, "templates", "robin.yml"), "utf8");
 const readme = readFileSync(join(repoRoot, "README.md"), "utf8");
+const advancedDocs = readFileSync(join(repoRoot, "docs", "ADVANCED.md"), "utf8");
+const actionYml = readFileSync(join(repoRoot, "action.yml"), "utf8");
 
 const slashCommandGate =
   "startsWith(github.event.comment.body, '/robin')";
+
+/** Inputs that are secrets / token on the action, not workflow_call inputs. */
+const ACTION_ONLY_SECRETS = new Set([
+  "github-token",
+  "llm-api-key",
+  "llm-base-url",
+  "model",
+]);
+
+/** Workflow-only input (not an action input). */
+const WORKFLOW_ONLY_INPUTS = new Set(["runner"]);
+
+/** Empty default means "defer to .github/robin.yml" — must stay string, not boolean. */
+const DEFER_TO_CONFIG_INPUTS = ["request-changes", "use-json-response-mode"] as const;
+
+function parseActionInputs(source: string): string[] {
+  return [...source.matchAll(/^  ([a-z0-9-]+):\n    description:/gm)].map(
+    (match) => match[1],
+  );
+}
+
+function publicActionInputs(): string[] {
+  return parseActionInputs(actionYml).filter((name) => !ACTION_ONLY_SECRETS.has(name));
+}
+
+/** Keys under `on.workflow_call.inputs` (4-space indent under `inputs:`). */
+function workflowCallInputNames(source: string): string[] {
+  const callSection = source.split(/\n\s+secrets:\n/)[0] ?? source;
+  const inputsBlock = callSection.split(/\n\s+inputs:\n/)[1];
+  if (!inputsBlock) return [];
+  return [...inputsBlock.matchAll(/^      ([a-z0-9-]+):\n/gm)].map((match) => match[1]);
+}
+
+/**
+ * Collect `key:` names from a YAML mapping that starts after `with:`.
+ * Skips blank lines and `#` comments so fixtures can document values.
+ */
+function mappingKeysAfterWith(source: string, withIndent: string): string[] {
+  const marker = `\n${withIndent}with:\n`;
+  const start = source.indexOf(marker);
+  if (start < 0) return [];
+  const body = source.slice(start + marker.length);
+  const keyIndent = `${withIndent}  `;
+  const keys: string[] = [];
+  for (const line of body.split("\n")) {
+    if (line.trim() === "" || line.trimStart().startsWith("#")) continue;
+    if (!line.startsWith(keyIndent)) break;
+    if (line.slice(keyIndent.length).startsWith(" ")) continue; // nested
+    const match = line.slice(keyIndent.length).match(/^([a-z0-9-]+):/);
+    if (match) keys.push(match[1]);
+  }
+  return keys;
+}
+
+/** `with:` keys on the Robin action step inside review.yml. */
+function forwardedActionInputNames(source: string): string[] {
+  return mappingKeysAfterWith(source, "        ").filter(
+    (name) => !ACTION_ONLY_SECRETS.has(name),
+  );
+}
+
+/** Top-level `with:` keys under the consumer job that calls the reusable workflow. */
+function consumerWorkflowWithKeys(source: string): string[] {
+  return mappingKeysAfterWith(source, "    ");
+}
+
+function workflowCallInputBlock(source: string, name: string): string | undefined {
+  const callSection = source.split(/\n\s+secrets:\n/)[0] ?? source;
+  const match = callSection.match(
+    new RegExp(`^      ${name}:\\n((?:        [^\\n]*\\n)+)`, "m"),
+  );
+  return match?.[1];
+}
 
 describe("reusable review workflow", () => {
   it.each([
@@ -27,24 +102,41 @@ describe("reusable review workflow", () => {
   });
 
   it("exposes every non-secret action input through workflow_call and forwards it", () => {
-    // Secrets / token are wired separately; runner is workflow-only.
-    const actionOnlySecrets = new Set([
-      "github-token",
-      "llm-api-key",
-      "llm-base-url",
-      "model",
-    ]);
-    const action = readFileSync(join(repoRoot, "action.yml"), "utf8");
-    const actionInputs = [
-      ...action.matchAll(/^  ([a-z0-9-]+):\n    description:/gm),
-    ].map((match) => match[1]);
-    const publicInputs = actionInputs.filter((name) => !actionOnlySecrets.has(name));
+    const expected = [...publicActionInputs(), ...WORKFLOW_ONLY_INPUTS].sort();
+    expect(workflowCallInputNames(reviewWorkflow).sort()).toEqual(expected);
 
-    const workflowCallSection = reviewWorkflow.split("secrets:")[0];
-    for (const name of publicInputs) {
-      expect(workflowCallSection).toContain(`      ${name}:`);
+    const forwarded = forwardedActionInputNames(reviewWorkflow).sort();
+    expect(forwarded).toEqual(publicActionInputs().sort());
+
+    for (const name of publicActionInputs()) {
       expect(reviewWorkflow).toContain(`${name}: \${{ inputs.${name} }}`);
     }
+  });
+
+  it("keeps defer-to-config knobs as empty-default strings (not booleans)", () => {
+    for (const name of DEFER_TO_CONFIG_INPUTS) {
+      const block = workflowCallInputBlock(reviewWorkflow, name);
+      expect(block).toBeDefined();
+      expect(block).toContain("type: string");
+      expect(block).toContain('default: ""');
+    }
+  });
+
+  it("documents every public action input in ADVANCED.md", () => {
+    for (const name of publicActionInputs()) {
+      expect(advancedDocs).toContain(`\`${name}\``);
+    }
+  });
+
+  it("keeps a consumer fixture that exercises every workflow_call input", () => {
+    const fixtureDir = join(repoRoot, "testdata", "consumer-workflows");
+    const fixtures = readdirSync(fixtureDir).filter((name) => name.endsWith(".yml"));
+    expect(fixtures).toContain("all-inputs.yml");
+
+    const fixture = readFileSync(join(fixtureDir, "all-inputs.yml"), "utf8");
+    expect(consumerWorkflowWithKeys(fixture).sort()).toEqual(
+      workflowCallInputNames(reviewWorkflow).sort(),
+    );
   });
 
   it("lets callers choose a GitHub-hosted or self-hosted runner", () => {

--- a/src/workflow.test.ts
+++ b/src/workflow.test.ts
@@ -33,7 +33,12 @@ const WORKFLOW_ONLY_INPUTS = new Set(["runner"]);
 const DEFER_TO_CONFIG_INPUTS = ["request-changes", "use-json-response-mode"] as const;
 
 function parseActionInputs(source: string): string[] {
-  return [...source.matchAll(/^  ([a-z0-9-]+):\n    description:/gm)].map(
+  // Scope to the inputs: section so a future outputs: block cannot pollute parity.
+  const inputsBlock = source
+    .split(/^inputs:\n/m)[1]
+    ?.split(/^(?:outputs|runs|branding):/m)[0];
+  if (!inputsBlock) return [];
+  return [...inputsBlock.matchAll(/^  ([a-z0-9-]+):\n    description:/gm)].map(
     (match) => match[1],
   );
 }
@@ -111,6 +116,27 @@ describe("reusable review workflow", () => {
     for (const name of publicActionInputs()) {
       expect(reviewWorkflow).toContain(`${name}: \${{ inputs.${name} }}`);
     }
+  });
+
+  it("scopes action input parsing to the inputs section (ignores outputs)", () => {
+    const synthetic = [
+      "name: Test",
+      "inputs:",
+      "  fail-on-high:",
+      "    description: Fail on high",
+      "  request-changes:",
+      "    description: Advisor mode",
+      "outputs:",
+      "  summary:",
+      "    description: Review summary",
+      "runs:",
+      "  using: node24",
+      "",
+    ].join("\n");
+    expect(parseActionInputs(synthetic)).toEqual([
+      "fail-on-high",
+      "request-changes",
+    ]);
   });
 
   it("keeps defer-to-config knobs as empty-default strings (not booleans)", () => {

--- a/testdata/consumer-workflows/all-inputs.yml
+++ b/testdata/consumer-workflows/all-inputs.yml
@@ -1,7 +1,7 @@
 # Fixture: a consumer workflow that passes every reusable-workflow input.
 # actionlint validates these against review.yml's workflow_call schema — the
-# same class of failure Cesar hit when request-changes was missing from that
-# schema. Keep this in sync when adding action inputs.
+# same class of failure that occurs when an input is missing from that schema.
+# Keep this in sync when adding action inputs.
 name: Consumer all-inputs
 
 on:

--- a/testdata/consumer-workflows/all-inputs.yml
+++ b/testdata/consumer-workflows/all-inputs.yml
@@ -20,10 +20,9 @@ jobs:
     uses: ./.github/workflows/review.yml
     with:
       fail-on-high: false
-      # String-typed defer-to-config knobs: use an expression so actionlint
-      # does not treat a YAML bool as a type error. GitHub also accepts bare
-      # false / "false" at runtime.
-      request-changes: ${{ 'false' }}
+      # Boolean workflow_call input — bare false matches real consumer YAML
+      # (e.g. request-changes: false). Omit to defer to .github/robin.yml.
+      request-changes: false
       max-diff-size: "25000"
       max-comments: "10"
       max-output-tokens: ""
@@ -33,6 +32,7 @@ jobs:
       review-instructions: ""
       review-on-synchronize: false
       config-file: .github/robin.yml
+      # String-typed defer-to-config knob: expression avoids actionlint bool/string clash.
       use-json-response-mode: ${{ 'true' }}
       runner: '"ubuntu-latest"'
     secrets:

--- a/testdata/consumer-workflows/all-inputs.yml
+++ b/testdata/consumer-workflows/all-inputs.yml
@@ -1,0 +1,41 @@
+# Fixture: a consumer workflow that passes every reusable-workflow input.
+# actionlint validates these against review.yml's workflow_call schema — the
+# same class of failure Cesar hit when request-changes was missing from that
+# schema. Keep this in sync when adding action inputs.
+name: Consumer all-inputs
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  actions: read
+
+jobs:
+  review:
+    uses: ./.github/workflows/review.yml
+    with:
+      fail-on-high: false
+      # String-typed defer-to-config knobs: use an expression so actionlint
+      # does not treat a YAML bool as a type error. GitHub also accepts bare
+      # false / "false" at runtime.
+      request-changes: ${{ 'false' }}
+      max-diff-size: "25000"
+      max-comments: "10"
+      max-output-tokens: ""
+      llm-timeout-ms: "600000"
+      min-command-permission: write
+      review-instructions-file: .github/code-reviewer.md
+      review-instructions: ""
+      review-on-synchronize: false
+      config-file: .github/robin.yml
+      use-json-response-mode: ${{ 'true' }}
+      runner: '"ubuntu-latest"'
+    secrets:
+      LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+      LLM_BASE_URL: ${{ secrets.LLM_BASE_URL }}
+      LLM_MODEL: ${{ secrets.LLM_MODEL }}


### PR DESCRIPTION
## Summary
- #61 shipped `request-changes` on the action and `.github/robin.yml`, but not on `.github/workflows/review.yml`, so reusable-workflow callers got `Invalid input, request-changes is not defined`.
- Declares and forwards `request-changes`, plus the other documented-but-missing inputs (`config-file`, `use-json-response-mode`).
- Hardens dual-entry parity: consumer fixture + actionlint in Self-Test (checksum-verified install) + Jest set-equality tests + PR/CONTRIBUTING checklist.
- Docs: advisor-mode example; clarify string defaults so empty still defers to repo config.

## Root cause
Reusable workflows only accept inputs listed under `on.workflow_call.inputs`. Adding an action input alone is not enough for the common `uses: .../review.yml@main` path.

## Test plan
- [x] `npm test` — 72 passed
- [x] Self-Test green (actionlint + suite) on latest commit
- [x] actionlint fails with Cesar-class error if `request-changes` is stripped from `review.yml` (verified locally)
- [x] Robin loop: pass-1 Medium fixed; pass-2 LEGIT Lows fixed; remaining Low/Suggestion justified as NOISE and threads resolved

Fixes the report on #59.