### PR TITLE
docs(install): clarify repository-scoped setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,12 @@ Read AGENTS.md in the robin repo for full rules.
 
 ## Quick install
 
-In a terminal, from your project folder, run either:
+> [!IMPORTANT]
+> Run the installer from the root of the Git repository you want Robin to review — not
+> from your home directory. The workflow and secrets are configured once per repository;
+> the companion agent skill is installed globally once per machine.
+
+From the target repository, run either:
 
 ```bash
 npx robin-review
@@ -51,6 +56,8 @@ curl -fsSL https://robinreview.dev/install.sh | bash
 
 Either one creates `.github/workflows/robin.yml` for you (it never overwrites an existing
 file) and installs the [companion chat skill](#robin-in-your-editor) into your coding agents.
+Run an installer separately in every repository that should use Robin. Re-running the
+global skill installation is safe and idempotent.
 You still need to add the three secrets — do **Steps 1 and 2** below, then commit and push.
 You can **skip Step 3**: the installer already did it.
 

--- a/bin/robin-review.js
+++ b/bin/robin-review.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * npx robin-review — adds the Robin code-review workflow to the current repo.
+ * From a Git repository root, npx robin-review adds Robin to that repository.
  * Node port of scripts/install.sh, so it works anywhere npx does (incl. Windows).
  *
  * Writes one file (.github/workflows/robin.yml), never overwrites an existing

--- a/llms.txt
+++ b/llms.txt
@@ -14,7 +14,7 @@
 
 ## Setup
 
-- One-line install (writes the workflow): `npx robin-review` or `curl -fsSL https://robinreview.dev/install.sh | bash`
+- From the target Git repository root, run `npx robin-review` or `curl -fsSL https://robinreview.dev/install.sh | bash`. The workflow and secrets are per repository; the companion agent skill is global per machine. Running either command from `~` fails because there is no target Git repository.
 - Or add `.github/workflows/robin.yml` calling `antongulin/robin/.github/workflows/review.yml@v1`.
 - Three secrets: `LLM_API_KEY`, `LLM_BASE_URL`, `LLM_MODEL`. Free OpenRouter: base `https://openrouter.ai/api/v1`, model `openrouter/free`.
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -2,6 +2,7 @@
 #
 # Robin installer — adds the Robin code-review workflow to the current repo.
 #
+# From the root of the Git repository you want Robin to review:
 #   curl -fsSL https://robinreview.dev/install.sh | bash
 #
 # It only writes one file (.github/workflows/robin.yml) in your repo and prints


### PR DESCRIPTION
## Summary

- clarify that npm and curl installers must run from the target Git repository
- distinguish per-repository workflow and secret setup from the globally installed companion skill
- align the README, CLI comments, install script, and machine-readable guidance

## Validation

- npm run lint
- npm test -- --runInBand (72 tests)
- git diff --check