### PR TITLE
feat: make LLM temperature configurable

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -34,6 +34,11 @@ on:
         required: false
         type: string
         default: "600000"
+      llm-temperature:
+        description: "Sampling temperature for LLM requests, between 0 and 2. Some models only accept a fixed value (for example Kimi requires 1)."
+        required: false
+        type: string
+        default: "0.1"
       min-command-permission:
         description: "Minimum repository permission required to run slash commands."
         required: false
@@ -117,6 +122,7 @@ jobs:
           max-comments: ${{ inputs.max-comments }}
           max-output-tokens: ${{ inputs.max-output-tokens }}
           llm-timeout-ms: ${{ inputs.llm-timeout-ms }}
+          llm-temperature: ${{ inputs.llm-temperature }}
           min-command-permission: ${{ inputs.min-command-permission }}
           review-instructions: ${{ inputs.review-instructions }}
           review-instructions-file: ${{ inputs.review-instructions-file }}

--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,10 @@ inputs:
     description: "Timeout in milliseconds for LLM requests. Default is 10 minutes (600000 ms). Increase if you frequently see 'Request timed out' with large diffs."
     required: false
     default: "600000"
+  llm-temperature:
+    description: "Sampling temperature for LLM requests, between 0 and 2. Default is 0.1 for near-deterministic reviews. Some models only accept a fixed value (for example Kimi requires 1)."
+    required: false
+    default: "0.1"
   max-comments:
     description: "Maximum number of inline review comments to post. Extra findings stay in the review body."
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -52,8 +52,9 @@ function hasRequiredPermission(permission, minimumPermission) {
 "use strict";
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-exports.DEFAULT_LLM_ROUTER_RETRY_DELAY_MS = exports.DEFAULT_LLM_RETRY_DELAY_MS = exports.DEFAULT_LLM_ROUTER_COMPLETION_ATTEMPTS = exports.DEFAULT_LLM_COMPLETION_ATTEMPTS = exports.DEFAULT_LLM_ROUTER_FIRST_CHUNK_MS = exports.DEFAULT_LLM_ROUTER_TIMEOUT_MS = exports.DEFAULT_LLM_TIMEOUT_MS = void 0;
+exports.MAX_LLM_TEMPERATURE = exports.DEFAULT_LLM_TEMPERATURE = exports.DEFAULT_LLM_ROUTER_RETRY_DELAY_MS = exports.DEFAULT_LLM_RETRY_DELAY_MS = exports.DEFAULT_LLM_ROUTER_COMPLETION_ATTEMPTS = exports.DEFAULT_LLM_COMPLETION_ATTEMPTS = exports.DEFAULT_LLM_ROUTER_FIRST_CHUNK_MS = exports.DEFAULT_LLM_ROUTER_TIMEOUT_MS = exports.DEFAULT_LLM_TIMEOUT_MS = void 0;
 exports.parseLLMTimeout = parseLLMTimeout;
+exports.parseLLMTemperature = parseLLMTemperature;
 exports.DEFAULT_LLM_TIMEOUT_MS = 600000; // 10 minutes
 exports.DEFAULT_LLM_ROUTER_TIMEOUT_MS = 120000; // 2 minutes — openrouter/free happy path is ~60-90s
 exports.DEFAULT_LLM_ROUTER_FIRST_CHUNK_MS = 45000; // no SSE = stacked router; fail fast and retry
@@ -61,6 +62,9 @@ exports.DEFAULT_LLM_COMPLETION_ATTEMPTS = 3;
 exports.DEFAULT_LLM_ROUTER_COMPLETION_ATTEMPTS = 5;
 exports.DEFAULT_LLM_RETRY_DELAY_MS = 2000;
 exports.DEFAULT_LLM_ROUTER_RETRY_DELAY_MS = 3000;
+exports.DEFAULT_LLM_TEMPERATURE = 0.1; // near-deterministic reviews
+/** OpenAI-compatible upper bound; some models (e.g. Kimi) only accept 1. */
+exports.MAX_LLM_TEMPERATURE = 2;
 function parseLLMTimeout(input) {
     if (!input)
         return { value: exports.DEFAULT_LLM_TIMEOUT_MS, valid: true };
@@ -69,6 +73,17 @@ function parseLLMTimeout(input) {
         return { value: parsed, valid: true };
     }
     return { value: exports.DEFAULT_LLM_TIMEOUT_MS, valid: false };
+}
+function parseLLMTemperature(input) {
+    const trimmed = input.trim();
+    if (!trimmed)
+        return { value: exports.DEFAULT_LLM_TEMPERATURE, valid: true };
+    const parsed = Number(trimmed);
+    // 0 is a legitimate value, so range-check instead of truthiness.
+    if (Number.isFinite(parsed) && parsed >= 0 && parsed <= exports.MAX_LLM_TEMPERATURE) {
+        return { value: parsed, valid: true };
+    }
+    return { value: exports.DEFAULT_LLM_TEMPERATURE, valid: false };
 }
 //# sourceMappingURL=config.js.map
 
@@ -665,9 +680,11 @@ class LLMClient {
     maxOutputTokens;
     maxAttempts;
     routerModel;
+    temperature;
     onProgress;
-    constructor(baseUrl, apiKey, model, maxOutputTokens, timeoutMs = config_1.DEFAULT_LLM_TIMEOUT_MS, maxAttempts = config_1.DEFAULT_LLM_COMPLETION_ATTEMPTS, onProgress) {
+    constructor(baseUrl, apiKey, model, maxOutputTokens, timeoutMs = config_1.DEFAULT_LLM_TIMEOUT_MS, maxAttempts = config_1.DEFAULT_LLM_COMPLETION_ATTEMPTS, temperature = config_1.DEFAULT_LLM_TEMPERATURE, onProgress) {
         this.model = model;
+        this.temperature = temperature;
         this.routerModel = (0, llm_retry_1.isOpenRouterRouterModel)(model);
         this.onProgress = onProgress;
         this.maxOutputTokens =
@@ -676,7 +693,7 @@ class LLMClient {
                 : undefined;
         this.maxAttempts = (0, llm_retry_1.getLlmCompletionAttemptCount)(maxAttempts, model);
         const effectiveTimeoutMs = (0, llm_retry_1.resolveLlmTimeoutMs)(model, timeoutMs);
-        core.info(`Initializing LLM client: baseUrl=${baseUrl}, model=${model}, timeout=${effectiveTimeoutMs} ms, maxAttempts=${this.maxAttempts}`);
+        core.info(`Initializing LLM client: baseUrl=${baseUrl}, model=${model}, timeout=${effectiveTimeoutMs} ms, maxAttempts=${this.maxAttempts}, temperature=${this.temperature}`);
         // ponytail: chatCompletion owns retries; SDK maxRetries × 10-min timeout burned whole job budgets
         this.client = new openai_1.OpenAI({
             baseURL: baseUrl,
@@ -812,7 +829,7 @@ class LLMClient {
                 { role: "system", content: systemPrompt },
                 { role: "user", content: userContent },
             ],
-            temperature: 0.1,
+            temperature: this.temperature,
         };
         if (this.maxOutputTokens) {
             request.max_tokens = this.maxOutputTokens;
@@ -1076,6 +1093,11 @@ async function run() {
         if (!llmTimeoutValid) {
             core.warning(`Invalid llm-timeout-ms value "${llmTimeoutMsInput}", using default ${config_1.DEFAULT_LLM_TIMEOUT_MS}`);
         }
+        const llmTemperatureInput = core.getInput("llm-temperature") || "";
+        const { value: llmTemperature, valid: llmTemperatureValid } = (0, config_1.parseLLMTemperature)(llmTemperatureInput);
+        if (!llmTemperatureValid) {
+            core.warning(`Invalid llm-temperature value "${llmTemperatureInput}", using default ${config_1.DEFAULT_LLM_TEMPERATURE}`);
+        }
         const inlineReviewInstructions = core.getInput("review-instructions") || "";
         const reviewInstructionsFile = core.getInput("review-instructions-file") || "";
         const configFile = core.getInput("config-file") || repo_config_1.DEFAULT_CONFIG_FILE;
@@ -1147,7 +1169,7 @@ async function run() {
         const reviewInstructions = command === "review"
             ? await loadReviewInstructions(octokit, gitUtils, owner, repo, prNumber, inlineReviewInstructions, reviewInstructionsFile, baseRef)
             : "";
-        const llm = new llm_client_1.LLMClient(baseUrl, apiKey, model, maxOutputTokens, llmTimeoutMs, undefined, async (detail) => {
+        const llm = new llm_client_1.LLMClient(baseUrl, apiKey, model, maxOutputTokens, llmTimeoutMs, undefined, llmTemperature, async (detail) => {
             await updateStatusComment(octokit, owner, repo, statusCommentId, buildProgressStatusBody(detail, statusCommand, statusModel));
         });
         const useJsonMode = command === "review" && jsonResponseMode;

--- a/docs/ADVANCED.md
+++ b/docs/ADVANCED.md
@@ -114,6 +114,7 @@ Available on the [direct action](../action.yml) and the [reusable workflow](../.
 | `max-diff-size` | `50000` | Max diff characters sent to the model |
 | `max-output-tokens` | empty | Cap response tokens (optional) |
 | `llm-timeout-ms` | `600000` | LLM timeout (10 minutes) |
+| `llm-temperature` | `0.1` | Sampling temperature (0–2). Raise only if your model rejects the default — some models accept a single fixed value (Kimi requires `1`) |
 | `max-comments` | `15` | Max inline comments |
 | `review-on-synchronize` | `false` | Review every new commit on the PR |
 | `runner` | `'"ubuntu-latest"'` | Reusable workflow only: runner as a JSON string or JSON array |
@@ -230,6 +231,28 @@ jobs:
 
 If you raise `llm-timeout-ms` above 10 minutes, also raise the job `timeout-minutes`.
 
+### Models that require a fixed temperature
+
+Robin samples at `0.1` so reviews stay near-deterministic. Some providers reject that and
+accept only one value — Kimi models require `1`, and the request fails without it. Set
+`llm-temperature` to whatever the provider demands:
+
+```yaml
+jobs:
+  review:
+    uses: antongulin/robin/.github/workflows/review.yml@main
+    with:
+      llm-temperature: "1"
+    secrets:
+      LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
+      LLM_BASE_URL: ${{ secrets.LLM_BASE_URL }}
+      LLM_MODEL: ${{ secrets.LLM_MODEL }}
+```
+
+Accepted range is 0–2. Out-of-range or non-numeric values log a warning and fall back to
+`0.1`. Raising temperature makes findings less repeatable, so change it only when the
+provider requires it.
+
 ## Review flow
 
 1. PR opened, reopened, or marked ready for review → automatic review.
@@ -305,6 +328,7 @@ No daily quota from this action. Real limits:
 | Job cancelled / 15 min with no review | Hung LLM or concurrency cancel while waiting | Status comment should say interrupted — comment `/robin` again; pin `@v2.0.4`+ for stall detect |
 | `404 Provider returned error` | OpenRouter free route missed one provider | Keep `LLM_MODEL=openrouter/free` — action retries (5×) with provider fallbacks; no secret updates when models rotate |
 | `Request timed out` | Large PR or slow free model | Lower `max-diff-size` or raise `llm-timeout-ms` (router models default to 2 min per attempt) |
+| `temperature` rejected / must be 1 | Model accepts only one temperature | Set `llm-temperature` to the value the provider requires (Kimi: `1`) |
 | `Resource not accessible by integration` | Missing permissions | Add `pull-requests: write` |
 | Slash command ignored | Wrong format or permission | `/robin` or `/review` as first line; need write access |
 | `/robin` does nothing on `@v1` | Stale `v1` tag before v1.4.0 | Use `/review`, pin `@v1.4.0`+, or `@v2`; floating `v1` tracks latest `1.x` on release |

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -1,4 +1,9 @@
-import { DEFAULT_LLM_TIMEOUT_MS, parseLLMTimeout } from "./config";
+import {
+  DEFAULT_LLM_TEMPERATURE,
+  DEFAULT_LLM_TIMEOUT_MS,
+  parseLLMTemperature,
+  parseLLMTimeout,
+} from "./config";
 
 describe("parseLLMTimeout", () => {
   it("returns the default for empty input", () => {
@@ -41,6 +46,62 @@ describe("parseLLMTimeout", () => {
   it("falls back for whitespace-only string", () => {
     const result = parseLLMTimeout("   ");
     expect(result.value).toBe(DEFAULT_LLM_TIMEOUT_MS);
+    expect(result.valid).toBe(false);
+  });
+});
+
+describe("parseLLMTemperature", () => {
+  it("returns the default for empty input", () => {
+    const result = parseLLMTemperature("");
+    expect(result.value).toBe(DEFAULT_LLM_TEMPERATURE);
+    expect(result.valid).toBe(true);
+  });
+
+  it("returns the default for whitespace-only input", () => {
+    const result = parseLLMTemperature("  ");
+    expect(result.value).toBe(DEFAULT_LLM_TEMPERATURE);
+    expect(result.valid).toBe(true);
+  });
+
+  it("parses the fixed temperature some models require", () => {
+    const result = parseLLMTemperature("1");
+    expect(result.value).toBe(1);
+    expect(result.valid).toBe(true);
+  });
+
+  it("accepts zero as a real value, not a fallback", () => {
+    const result = parseLLMTemperature("0");
+    expect(result.value).toBe(0);
+    expect(result.valid).toBe(true);
+  });
+
+  it("parses a float string", () => {
+    const result = parseLLMTemperature("0.7");
+    expect(result.value).toBe(0.7);
+    expect(result.valid).toBe(true);
+  });
+
+  it("accepts the OpenAI-compatible upper bound", () => {
+    const result = parseLLMTemperature("2");
+    expect(result.value).toBe(2);
+    expect(result.valid).toBe(true);
+  });
+
+  it("falls back above the upper bound", () => {
+    const result = parseLLMTemperature("2.5");
+    expect(result.value).toBe(DEFAULT_LLM_TEMPERATURE);
+    expect(result.valid).toBe(false);
+  });
+
+  it("falls back for negative values", () => {
+    const result = parseLLMTemperature("-1");
+    expect(result.value).toBe(DEFAULT_LLM_TEMPERATURE);
+    expect(result.valid).toBe(false);
+  });
+
+  it("falls back for NaN string", () => {
+    const result = parseLLMTemperature("hot");
+    expect(result.value).toBe(DEFAULT_LLM_TEMPERATURE);
     expect(result.valid).toBe(false);
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,9 @@ export const DEFAULT_LLM_COMPLETION_ATTEMPTS = 3;
 export const DEFAULT_LLM_ROUTER_COMPLETION_ATTEMPTS = 5;
 export const DEFAULT_LLM_RETRY_DELAY_MS = 2000;
 export const DEFAULT_LLM_ROUTER_RETRY_DELAY_MS = 3000;
+export const DEFAULT_LLM_TEMPERATURE = 0.1; // near-deterministic reviews
+/** OpenAI-compatible upper bound; some models (e.g. Kimi) only accept 1. */
+export const MAX_LLM_TEMPERATURE = 2;
 
 export function parseLLMTimeout(input: string): { value: number; valid: boolean } {
   if (!input) return { value: DEFAULT_LLM_TIMEOUT_MS, valid: true };
@@ -13,4 +16,15 @@ export function parseLLMTimeout(input: string): { value: number; valid: boolean 
     return { value: parsed, valid: true };
   }
   return { value: DEFAULT_LLM_TIMEOUT_MS, valid: false };
+}
+
+export function parseLLMTemperature(input: string): { value: number; valid: boolean } {
+  const trimmed = input.trim();
+  if (!trimmed) return { value: DEFAULT_LLM_TEMPERATURE, valid: true };
+  const parsed = Number(trimmed);
+  // 0 is a legitimate value, so range-check instead of truthiness.
+  if (Number.isFinite(parsed) && parsed >= 0 && parsed <= MAX_LLM_TEMPERATURE) {
+    return { value: parsed, valid: true };
+  }
+  return { value: DEFAULT_LLM_TEMPERATURE, valid: false };
 }

--- a/src/llm-client.ts
+++ b/src/llm-client.ts
@@ -2,6 +2,7 @@ import { OpenAI } from "openai";
 import {
   DEFAULT_LLM_COMPLETION_ATTEMPTS,
   DEFAULT_LLM_ROUTER_FIRST_CHUNK_MS,
+  DEFAULT_LLM_TEMPERATURE,
   DEFAULT_LLM_TIMEOUT_MS,
 } from "./config";
 import {
@@ -29,6 +30,7 @@ export class LLMClient {
   private maxOutputTokens?: number;
   private maxAttempts: number;
   private routerModel: boolean;
+  private temperature: number;
   private onProgress?: LlmProgressHandler;
 
   constructor(
@@ -38,9 +40,11 @@ export class LLMClient {
     maxOutputTokens?: number,
     timeoutMs = DEFAULT_LLM_TIMEOUT_MS,
     maxAttempts = DEFAULT_LLM_COMPLETION_ATTEMPTS,
+    temperature = DEFAULT_LLM_TEMPERATURE,
     onProgress?: LlmProgressHandler
   ) {
     this.model = model;
+    this.temperature = temperature;
     this.routerModel = isOpenRouterRouterModel(model);
     this.onProgress = onProgress;
     this.maxOutputTokens =
@@ -51,7 +55,7 @@ export class LLMClient {
     const effectiveTimeoutMs = resolveLlmTimeoutMs(model, timeoutMs);
 
     core.info(
-      `Initializing LLM client: baseUrl=${baseUrl}, model=${model}, timeout=${effectiveTimeoutMs} ms, maxAttempts=${this.maxAttempts}`
+      `Initializing LLM client: baseUrl=${baseUrl}, model=${model}, timeout=${effectiveTimeoutMs} ms, maxAttempts=${this.maxAttempts}, temperature=${this.temperature}`
     );
 
     // ponytail: chatCompletion owns retries; SDK maxRetries × 10-min timeout burned whole job budgets
@@ -232,7 +236,7 @@ export class LLMClient {
         { role: "system", content: systemPrompt },
         { role: "user", content: userContent },
       ],
-      temperature: 0.1,
+      temperature: this.temperature,
     };
 
     if (this.maxOutputTokens) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,12 @@ import { GitUtils } from "./git-utils";
 import { ReviewParser, StructuredReview } from "./review-parser";
 import { shouldRetryStructuredReview } from "./review-retry";
 import { GitHubReviewer, ROBIN_SIGNATURE } from "./github-reviewer";
-import { DEFAULT_LLM_TIMEOUT_MS, parseLLMTimeout } from "./config";
+import {
+  DEFAULT_LLM_TEMPERATURE,
+  DEFAULT_LLM_TIMEOUT_MS,
+  parseLLMTemperature,
+  parseLLMTimeout,
+} from "./config";
 import { filterDiff, splitDiffIntoFiles } from "./diff-filter";
 import { annotateDiffWithLineNumbers } from "./diff-annotate";
 import {
@@ -126,6 +131,14 @@ async function run(): Promise<void> {
     const { value: llmTimeoutMs, valid: llmTimeoutValid } = parseLLMTimeout(llmTimeoutMsInput);
     if (!llmTimeoutValid) {
       core.warning(`Invalid llm-timeout-ms value "${llmTimeoutMsInput}", using default ${DEFAULT_LLM_TIMEOUT_MS}`);
+    }
+    const llmTemperatureInput = core.getInput("llm-temperature") || "";
+    const { value: llmTemperature, valid: llmTemperatureValid } =
+      parseLLMTemperature(llmTemperatureInput);
+    if (!llmTemperatureValid) {
+      core.warning(
+        `Invalid llm-temperature value "${llmTemperatureInput}", using default ${DEFAULT_LLM_TEMPERATURE}`
+      );
     }
     const inlineReviewInstructions = core.getInput("review-instructions") || "";
     const reviewInstructionsFile = core.getInput("review-instructions-file") || "";
@@ -260,6 +273,7 @@ async function run(): Promise<void> {
       maxOutputTokens,
       llmTimeoutMs,
       undefined,
+      llmTemperature,
       async (detail) => {
         await updateStatusComment(
           octokit!,

--- a/testdata/consumer-workflows/all-inputs.yml
+++ b/testdata/consumer-workflows/all-inputs.yml
@@ -27,6 +27,7 @@ jobs:
       max-comments: "10"
       max-output-tokens: ""
       llm-timeout-ms: "600000"
+      llm-temperature: "0.1"
       min-command-permission: write
       review-instructions-file: .github/code-reviewer.md
       review-instructions: ""


### PR DESCRIPTION
**What & why**

`buildRequest` hard-coded `temperature: 0.1`, so providers that accept only one temperature could not be used at all — Kimi models require `1` and reject the request otherwise. This adds an `llm-temperature` input, threaded from both entry points through `main.ts` into `LLMClient`, which now uses it in place of the literal. Default stays `0.1`, so nothing changes for existing consumers.

Parsing lives in `parseLLMTemperature` alongside `parseLLMTimeout` and follows the same `{ value, valid }` shape: range-checked to 0–2 (the OpenAI-compatible range) instead of tested for truthiness, so `0` stays a usable value. Out-of-range or non-numeric input warns and falls back to the default rather than failing the job. The resolved temperature is now part of the LLM client init log line, so a provider that rejects it is easy to diagnose from the job log.

This makes the review action compatible with Kimi K3 using the Moonshot API.

**Type**
- [ ] Bug fix
- [x] Feature
- [ ] Docs
- [ ] Refactor / chore

**Verification**
- [x] `npm run lint`
- [x] `npm test` — 94 passing, including 9 new `parseLLMTemperature` cases (`1` for Kimi, `0` as a real value, bounds, fallbacks)
- [x] `npm run build` (`dist/index.js` committed; `git diff --exit-code dist/index.js` clean on Node 24)
- [x] `actionlint 1.7.12 -shellcheck= -pyflakes= .github/workflows/*.yml testdata/consumer-workflows/*.yml` — clean
- [ ] End-to-end against a Kimi endpoint that rejects `0.1` — tick once the real run is confirmed

**Dual entry points** (required when adding/changing an action input)
- [x] `action.yml` input added/updated
- [x] `.github/workflows/review.yml` `workflow_call` input + forward to the action step
- [ ] `.github/robin.yml` / repo-config parser — deliberately skipped, see Notes
- [x] `docs/ADVANCED.md` + example if user-facing — input table row, a "Models that require a fixed temperature" usage pattern, and a troubleshooting row
- [x] `testdata/consumer-workflows/all-inputs.yml` updated (actionlint + Jest parity)

**Notes**

No breaking change and no migration: the input defaults to `0.1`, the previous hard-coded value.

I left this out of the repo-config parser on purpose, but happy to add it if you'd rather have it there. Two reasons: `llm-timeout-ms` and the other LLM transport knobs aren't in `.github/robin.yml` either, and the required temperature is a property of the endpoint selected by `LLM_MODEL` / `LLM_BASE_URL` — which are workflow secrets — so the workflow seemed like the honest place to keep the two in sync.

Worth reviewers' attention: the upper bound of 2. It follows the OpenAI-compatible range, so `1.5` is accepted rather than silently downgraded to `0.1`; if you'd prefer to cap at 1, that's a one-line change to `MAX_LLM_TEMPERATURE`.