### PR TITLE
docs(repo): require safe session Git synchronization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,9 +1,8 @@
 # Instructions for AI coding agents
 
-Start every session by inspecting Git status and worktrees, fetching origin with pruning, safely fast-forwarding local main, and verifying main matches origin/main. Only then create a task branch from synchronized main if needed. Preserve existing task branches and unfinished work. Never reset, discard changes, auto-stash, or force-push merely to synchronize. If safe synchronization is blocked, resolve the blocker before editing or branching.
-
-
 Use this file when adding Robin to **another** repository.
+
+Start every session by inspecting Git status and worktrees, fetching origin with pruning, safely fast-forwarding local main, and verifying main matches origin/main. Only then create a task branch from synchronized main if needed. Preserve existing task branches and unfinished work. Never reset, discard changes, auto-stash, or force-push merely to synchronize. If safe synchronization is blocked, resolve the blocker before editing or branching.
 
 ## Required workflow reference
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,8 @@
 # Instructions for AI coding agents
 
+Start every session by inspecting Git status and worktrees, fetching origin with pruning, safely fast-forwarding local main, and verifying main matches origin/main. Only then create a task branch from synchronized main if needed. Preserve existing task branches and unfinished work. Never reset, discard changes, auto-stash, or force-push merely to synchronize. If safe synchronization is blocked, resolve the blocker before editing or branching.
+
+
 Use this file when adding Robin to **another** repository.
 
 ## Required workflow reference


### PR DESCRIPTION
Adds the required session-start Git synchronization and preservation rule to the root agent instructions. Existing local work and stashes remain preserved.

Validation: git diff --check passed; only the root agent instructions changed. Local main matches origin/main after fast-forward synchronization. No application, runtime maintenance, or deployment commands were run.
